### PR TITLE
Cmis read

### DIFF
--- a/cmis_read/__init__.py
+++ b/cmis_read/__init__.py
@@ -1,0 +1,25 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    This module copyright (C) 2014 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import wizard
+
+# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/cmis_read/__openerp__.py
+++ b/cmis_read/__openerp__.py
@@ -1,0 +1,74 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    This module copyright (C) 2014 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+{
+    'name': 'CMIS Read',
+    'version': '0.1',
+    'category': 'Knowledge Management',
+    'summary': 'Store Document File in a Remote CMIS Server',
+    'description': """
+This module allows you to use the CMIS backend to search in the DMS repository
+and attach documents to OpenERP records.
+
+Configuration
+=============
+
+Create a new CMIS backend with the host, login and password.
+
+Usage
+=====
+
+* On one OpenERP record, click "Add from DMS".
+* Type your query and then click on "Search".
+* Filter your results if necessary
+* Select the documents you want to attach
+* Selected documents will be enqueued for importing
+
+Contributors
+------------
+* El Hadji Dem (elhadji.dem@savoirfairelinux.com)
+""",
+    'author': 'Savoir-faire Linux',
+    'website': 'www.savoirfairelinux.com',
+    'license': 'AGPL-3',
+    'depends': [
+        'document',
+        'cmis'
+    ],
+    'data': [
+        'security/ir.model.access.csv',
+        'wizard/document_wizard_view.xml',
+    ],
+    'js': [
+        'static/src/js/document.js'
+    ],
+    'qweb': [
+        'static/src/xml/document.xml'
+    ],
+    'test': [],
+    'demo': [
+    ],
+    'installable': True,
+    'auto_install': False,
+}
+
+# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/cmis_read/i18n/cmis_read.pot
+++ b/cmis_read/i18n/cmis_read.pot
@@ -1,0 +1,119 @@
+# Translation of OpenERP Server.
+# This file contains the translation of the following modules:
+# 	* cmis_read
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: OpenERP Server 7.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2014-03-21 14:55+0000\n"
+"PO-Revision-Date: 2014-03-21 10:55-0500\n"
+"Last-Translator: EL Hadji DEM <elhadji.dem@savoirfairelinux.com>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: \n"
+"X-Generator: Poedit 1.5.4\n"
+
+#. module: cmis_read
+#: field:ir.attachment.dms,file_id:0
+msgid "File ID"
+msgstr ""
+
+#. module: cmis_read
+#: field:ir.attachment.dms.wizard,attachment_ids:0
+msgid "Attachments"
+msgstr ""
+
+#. module: cmis_read
+#: view:ir.attachment.dms.wizard:0
+msgid "Search Document"
+msgstr ""
+
+#. module: cmis_read
+#: field:ir.attachment.dms,name:0 help:ir.attachment.dms,name:0
+#: field:ir.attachment.dms.wizard,name:0 help:ir.attachment.dms.wizard,name:0
+msgid "File name"
+msgstr ""
+
+#. module: cmis_read
+#: code:addons/cmis_read/wizard/document_wizard.py:59
+#, python-format
+msgid "You have to fill in the file name. And try again"
+msgstr ""
+
+#. module: cmis_read
+#: help:ir.attachment.dms,file_id:0
+msgid "File Id"
+msgstr ""
+
+#. module: cmis_read
+#: model:_description:0 model:ir.model,name:cmis_read.model_ir_attachment_dms
+msgid "ir.attachment.dms"
+msgstr ""
+
+#. module: cmis_read
+#: field:ir.attachment.dms,owner:0 help:ir.attachment.dms,owner:0
+msgid "Owner"
+msgstr ""
+
+#. module: cmis_read
+#: view:ir.attachment.dms.wizard:0
+msgid ""
+"This action allows you to search by file name and to add the document you "
+"select"
+msgstr ""
+
+#. module: cmis_read
+#. openerp-web
+#: code:addons/cmis_read/static/src/js/document.js:26
+#, python-format
+msgid "Search Document from DMS"
+msgstr ""
+
+#. module: cmis_read
+#. openerp-web
+#: code:addons/cmis_read/static/src/xml/document.xml:7
+#, python-format
+msgid "Add Doc from DMS..."
+msgstr ""
+
+#. module: cmis_read
+#: code:addons/cmis_read/wizard/document_wizard.py:58
+#: code:addons/cmis_read/wizard/document_wizard.py:86
+#, python-format
+msgid "Error"
+msgstr ""
+
+#. module: cmis_read
+#: view:ir.attachment.dms.wizard:0
+msgid "Cancel"
+msgstr ""
+
+#. module: cmis_read
+#: view:ir.attachment.dms.wizard:0
+msgid "Apply"
+msgstr ""
+
+#. module: cmis_read
+#: model:_description:0
+#: model:ir.model,name:cmis_read.model_ir_attachment_dms_wizard
+msgid "ir.attachment.dms.wizard"
+msgstr ""
+
+#. module: cmis_read
+#: view:ir.attachment.dms.wizard:0
+msgid "Search"
+msgstr ""
+
+#. module: cmis_read
+#: view:ir.attachment.dms.wizard:0
+msgid "or"
+msgstr ""
+
+#. module: cmis_read
+#: code:addons/cmis_read/wizard/document_wizard.py:87
+#, python-format
+msgid "You have to select at least 1 Document. And try again"
+msgstr ""

--- a/cmis_read/security/ir.model.access.csv
+++ b/cmis_read/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_ir_attachment_dms_group_user,ir.attachment.dms user,model_ir_attachment_dms,base.group_document_user,1,1,1,1

--- a/cmis_read/security/ir.model.access.csv
+++ b/cmis_read/security/ir.model.access.csv
@@ -1,2 +1,2 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
-access_ir_attachment_dms_group_user,ir.attachment.dms user,model_ir_attachment_dms,base.group_document_user,1,1,1,1
+access_ir_attachment_dms_wizard,access_ir_attachment_dms_wizard,model_ir_attachment_dms_wizard,base.group_document_user,1,1,1,1

--- a/cmis_read/static/src/js/document.js
+++ b/cmis_read/static/src/js/document.js
@@ -1,0 +1,44 @@
+openerp.cmis_read = function(instance, m) {
+var _t = instance.web._t,
+    QWeb = instance.web.qweb;
+
+    instance.web.Sidebar.include({
+        redraw: function() {
+            var self = this;
+            this._super.apply(this, arguments);
+            self.$el.find('.oe_sidebar_add_attachment').after(QWeb.render('AddDocfromdms', {widget: self}))
+            self.$el.find('.oe_sidebar_add_dms_doc').on('click', function (e) {
+                self.on_cmis_doc();
+            });
+        },
+        on_cmis_doc: function(state) {
+            var self = this;
+            var view = self.getParent();
+            var ids = ( view.fields_view.type != "form" )? view.groups.get_selection().ids : [ view.datarecord.id ];
+            var ds = new instance.web.DataSet(this, 'ir.attachment', context);
+            // you can pass in other data using the context dictionary variable
+            var context = {
+            'model': view.dataset.model,
+            'ids': ids,
+            };
+            // the action dictionary variable sends data in the "self.do_action" method
+            var action = {
+                name: _t("Search Document from DMS"),
+                type: 'ir.actions.act_window',
+                res_model: 'ir.attachment.dms.wizard',
+                view_mode: 'form',
+                view_type: 'form',
+                views: [[false, 'form']],
+                target: 'new',
+                context: context,
+            };
+            // self.do_action accepts the action parameter and opens the new view
+            self.do_action(action, {
+                // refresh list of documents
+                on_close: function () {
+                    self.do_attachement_update(self.dataset, self.model_id);
+                }
+            });
+        }
+    });
+};

--- a/cmis_read/static/src/xml/document.xml
+++ b/cmis_read/static/src/xml/document.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- vim:fdl=1:
+-->
+<templates id="template" xml:space="preserve">
+
+<t t-name="AddDocfromdms">
+     <li class="oe_sidebar_add_dms_doc"><span><b>Add Doc from DMS...</b></span></li>
+</t>
+
+</templates>

--- a/cmis_read/wizard/__init__.py
+++ b/cmis_read/wizard/__init__.py
@@ -1,0 +1,25 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    This module copyright (C) 2014 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import document_wizard
+
+# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/cmis_read/wizard/document_wizard.py
+++ b/cmis_read/wizard/document_wizard.py
@@ -120,7 +120,10 @@ def search_doc_from_dms(session, model_name, backend_id, file_name):
     ir_attach_dms_obj.unlink(session.cr, session.uid,
                              attachment_ids, context=session.context)
     # Escape the name for characters not supported in filenames
-    file_name = file_name.replace('/', '_')
+    # for avoiding SQL Injection
+    file_name = file_name.replace("'", "\\'")
+    file_name = file_name.replace("%", "\%")
+    file_name = file_name.replace("_", "\_")
     # Get results from name of document
     results = repo.query(" SELECT cmis:name, cmis:createdBy, cmis:objectId, "
                          "cmis:contentStreamLength FROM  cmis:document "
@@ -166,8 +169,7 @@ def create_doc_from_dms(session, model_name, backend_id, data, name,
                 'res_id': res_id,
                 'user_id': uid,
             }
-            # Don't create doc again in DMS
-            session.context['bool_testdoc'] = True
+            session.context['bool_read_doc'] = True
             ir_attach_obj.create(session.cr, session.uid,
                                  data_attach, context=session.context)
     return True

--- a/cmis_read/wizard/document_wizard.py
+++ b/cmis_read/wizard/document_wizard.py
@@ -119,10 +119,12 @@ def search_doc_from_dms(session, model_name, backend_id, file_name):
     attachment_ids = ir_attach_dms_obj.search(session.cr, session.uid, [])
     ir_attach_dms_obj.unlink(session.cr, session.uid,
                              attachment_ids, context=session.context)
+    # Escape the name for characters not supported in filenames
+    file_name = file_name.replace('/', '_')
     # Get results from name of document
-    results = repo.query(" SELECT cmis:name, cmis:createdBy, cmis:objectId, \
-                         cmis:contentStreamLength FROM  cmis:document \
-                         WHERE cmis:name LIKE '%" + file_name + "%'")
+    results = repo.query(" SELECT cmis:name, cmis:createdBy, cmis:objectId, "
+                         "cmis:contentStreamLength FROM  cmis:document "
+                         "WHERE cmis:name LIKE '%" + file_name + "%'")
     for result in results:
         info = result.getProperties()
         if info['cmis:contentStreamLength'] != 0:

--- a/cmis_read/wizard/document_wizard.py
+++ b/cmis_read/wizard/document_wizard.py
@@ -166,7 +166,8 @@ def create_doc_from_dms(session, model_name, backend_id, data, name,
                 'res_id': res_id,
                 'user_id': uid,
             }
-            session.context['bool_read_doc'] = True
+            # Don't create doc again in DMS
+            session.context['bool_testdoc'] = True
             ir_attach_obj.create(session.cr, session.uid,
                                  data_attach, context=session.context)
     return True

--- a/cmis_read/wizard/document_wizard.py
+++ b/cmis_read/wizard/document_wizard.py
@@ -106,6 +106,15 @@ class ir_attachment_edm_wizard(orm.Model):
         return {'type': 'ir.actions.act_window_close'}
 
 
+def sanitize_input_filename_field(file_name):
+    # Escape the name for characters not supported in filenames
+    # for avoiding SQL Injection
+    file_name = file_name.replace("'", "\\'")
+    file_name = file_name.replace("%", "\%")
+    file_name = file_name.replace("_", "\_")
+    return file_name
+
+
 def search_doc_from_dms(session, model_name, backend_id, file_name):
     ir_attach_dms_obj = session.pool.get('ir.attachment.dms')
     cmis_backend_obj = session.pool.get('cmis.backend')
@@ -120,10 +129,7 @@ def search_doc_from_dms(session, model_name, backend_id, file_name):
     ir_attach_dms_obj.unlink(session.cr, session.uid,
                              attachment_ids, context=session.context)
     # Escape the name for characters not supported in filenames
-    # for avoiding SQL Injection
-    file_name = file_name.replace("'", "\\'")
-    file_name = file_name.replace("%", "\%")
-    file_name = file_name.replace("_", "\_")
+    file_name = sanitize_input_filename_field(file_name)
     # Get results from name of document
     results = repo.query(" SELECT cmis:name, cmis:createdBy, cmis:objectId, "
                          "cmis:contentStreamLength FROM  cmis:document "

--- a/cmis_read/wizard/document_wizard.py
+++ b/cmis_read/wizard/document_wizard.py
@@ -1,0 +1,152 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    This module copyright (C) 2014 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp.osv import orm, fields, osv
+from openerp.tools.translate import _
+from openerp.addons.connector.session import ConnectorSession
+from openerp.addons.connector.queue.job import job
+import logging
+_logger = logging.getLogger(__name__)
+
+
+class ir_attachment_dms(osv.TransientModel):
+    _name = 'ir.attachment.dms'
+
+    _columns = {
+        'name': fields.char('File name', size=150, readonly=True, help="File name"),
+        'owner': fields.char('Owner', size=150, readonly=True, help="Owner"),
+        'file_id': fields.char('File ID', size=150, readonly=True, help="File Id"),
+    }
+
+
+class ir_attachment_edm_wizard(orm.Model):
+    _name = 'ir.attachment.dms.wizard'
+
+    _columns = {
+        'name': fields.char('File name', size=150, help="File name"),
+        'attachment_ids': fields.many2many('ir.attachment.dms',
+                                           'document_attachment_dms_rel',
+                                           'wizard_id', 'attachment_id', 'Attachments'),
+    }
+
+    # Search documents from dms.
+    def search_doc(self, cr, uid, ids, context=None):
+        if context is None:
+            context = {}
+        this = self.browse(cr, uid, ids, context=context)[0]
+        data = self.read(cr, uid, ids, [], context=context)[0]
+        if not data['name']:
+            raise orm.except_orm(_('Error'),
+                                 _('You have to fill in the file name. And try again'))
+        if not hasattr(ids, '__iter__'):
+            ids = [ids]
+        session = ConnectorSession(cr, uid, context=context)
+        file_name = data['name']
+        for backend_id in ids:
+            search_doc_from_dms(session, 'ir.attachment', backend_id, file_name)
+        return {
+            'type': 'ir.actions.act_window',
+            'res_model': 'ir.attachment.dms.wizard',
+            'view_mode': 'form',
+            'view_type': 'form',
+            'res_id': this.id,
+            'views': [(False, 'form')],
+            'target': 'new',
+        }
+
+    # Adding documents from Document Management (EDM) to OE.
+    def action_apply(self, cr, uid, ids, context=None):
+        if context is None:
+            context = {}
+        model = context['model']
+        res_id = context['ids'][0]
+        ir_model_obj = self.pool.get(context['model'])
+        name = ir_model_obj.browse(cr, uid, context['ids'], context=context)[0]['name']
+        data = self.read(cr, uid, ids, [], context=context)[0]
+        if not data['attachment_ids']:
+            raise orm.except_orm(_('Error'),
+                                 _('You have to select at least 1 Document. And try again'))
+        if not hasattr(ids, '__iter__'):
+            ids = [ids]
+        session = ConnectorSession(cr, uid, context=context)
+        file_name = data['name']
+        for backend_id in ids:
+            # Create doc in OE from DMS.
+            create_doc_from_dms.delay(session, 'ir.attachment', backend_id, data, name, model, res_id)
+        return {'type': 'ir.actions.act_window_close'}
+
+
+def search_doc_from_dms(session, model_name, backend_id, file_name):
+    ir_attach_dms_obj = session.pool.get('ir.attachment.dms')
+    cmis_backend_obj = session.pool.get('cmis.backend')
+    if session.context is None:
+        session.context = {}
+    #login with the cmis account
+    client = cmis_backend_obj._auth(session.cr, session.uid, context=session.context)
+    repo = client.getDefaultRepository()
+
+     # Search name of doc and delete it if the document is already existed
+    attachment_ids = ir_attach_dms_obj.search(session.cr, session.uid, [])
+    ir_attach_dms_obj.unlink(session.cr, session.uid, attachment_ids, context=session.context)
+    # Get results from name of document
+    results = repo.query("SELECT cmis:name', cmis:createdBy, cmis:objectId  FROM  cmis:document WHERE cmis:name LIKE '%" + file_name + "%'")
+    for result in results:
+        info = result.getProperties()
+        if info['cmis:contentStreamLength'] != 0:
+            data_attach = {
+                'name': info['cmis:name'],
+                'owner': info['cmis:createdBy'],
+                'file_id': info['cmis:objectId'],
+            }
+        ir_attach_dms_obj.create(session.cr, session.uid, data_attach, context=session.context)
+
+
+@job
+def create_doc_from_dms(session, model_name, backend_id, data, name, model, res_id, filters=None):
+    ir_attach_obj = session.pool.get('ir.attachment')
+    ir_attach_dms_obj = session.pool.get('ir.attachment.dms')
+    cmis_backend_obj = session.pool.get('cmis.backend')
+    if session.context is None:
+        session.context = {}
+    #login with the cmis account
+    client = cmis_backend_obj._auth(session.cr, session.uid, context=session.context)
+    repo = client.getDefaultRepository()
+
+    for attach in ir_attach_dms_obj.browse(session.cr, session.uid, data['attachment_ids'],
+                                           context=session.context):
+        # Get results from id of document
+        results = repo.query("SELECT * FROM  cmis:document WHERE cmis:objectId ='" + attach.file_id + "'")
+        for result in results:
+            info = result.getProperties()
+            data_attach = {
+                'name': info['cmis:name'],
+                'type': 'binary',
+                'datas': result.getContentStream().read().encode("base64"),
+                'res_model': model,
+                'res_name': name,
+                'res_id': session.context['ids'][0],
+                'user_id': session.uid,
+            }
+            ir_attach_obj.create(session.cr, session.uid, data_attach, context=session.context)
+    return True
+
+# vim:expandtab:smartindent:toabstop=4:softtabstop=4:shiftwidth=4:

--- a/cmis_read/wizard/document_wizard_view.xml
+++ b/cmis_read/wizard/document_wizard_view.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<openerp>
+  <data>
+
+    <record id="document_from_dms_form_view" model="ir.ui.view">
+      <field name="name">Search Document</field>
+      <field name="model">ir.attachment.dms.wizard</field>
+      <field name="arch" type="xml">
+        <form string="Search Document" version="7.0">
+        <label string="This action allows you to search by file name and to add the document you select"/>
+        <group string="Search Document">
+          <div width="100%%">
+            <field  name="name"
+                    width="70%%"
+                    class="oe_inline"/>
+            <button name="search_doc"
+                    string="Search"
+                    type="object"
+                    width="15%%"
+                    class="oe_inline oe_highlight" />
+          </div>
+          <field name="attachment_ids" colspan="4" nolabel="1"/>
+        </group>
+        <footer>
+          <button name="action_apply" string="Apply" type="object" class="oe_highlight"/>
+          or
+          <button special="cancel" string="Cancel" type="object" class="oe_link"/>
+        </footer>
+      </form>
+      </field>
+    </record>
+
+  </data>
+</openerp>

--- a/cmis_read/wizard/document_wizard_view.xml
+++ b/cmis_read/wizard/document_wizard_view.xml
@@ -2,32 +2,45 @@
 <openerp>
   <data>
 
-    <record id="document_from_dms_form_view" model="ir.ui.view">
-      <field name="name">Search Document</field>
-      <field name="model">ir.attachment.dms.wizard</field>
-      <field name="arch" type="xml">
-        <form string="Search Document" version="7.0">
-        <label string="This action allows you to search by file name and to add the document you select"/>
-        <group string="Search Document">
-          <div width="100%%">
-            <field  name="name"
-                    width="70%%"
-                    class="oe_inline"/>
-            <button name="search_doc"
-                    string="Search"
-                    type="object"
-                    width="15%%"
-                    class="oe_inline oe_highlight" />
-          </div>
-          <field name="attachment_ids" colspan="4" nolabel="1"/>
-        </group>
-        <footer>
-          <button name="action_apply" string="Apply" type="object" class="oe_highlight"/>
-          or
-          <button special="cancel" string="Cancel" type="object" class="oe_link"/>
-        </footer>
-      </form>
-      </field>
+    <!-- wizard view -->
+        <record id="wizard_view" model="ir.ui.view">
+            <field name="name">Search Document</field>
+            <field name="model">ir.attachment.dms.wizard</field>
+            <field name="arch" type="xml">
+                <form string="Search Document" version="7.0">
+                   <div>
+                        This action allows you to search by file name and to add the document you select
+                   </div>
+                   <group>
+                      <div width="100%%">
+                        <field  name="name" width="70%%" class="oe_inline"/>
+                        <button name="search_doc" string="Search" type="object"
+                                width="15%%" class="oe_inline oe_highlight" />
+                      </div>
+                   </group>
+                    <field name="attachment_ids"/>
+                    <footer>
+                      <button name="action_apply" string="Apply" type="object"
+                              class="oe_highlight"/>
+                      or
+                      <button special="cancel" string="Cancel" type="object"
+                              class="oe_link"/>
+                    </footer>
+                </form>
+            </field>
+        </record>
+
+
+    <record id="wizard_attachment_tree_view" model="ir.ui.view">
+        <field name="name">Ir Attachment Dms</field>
+        <field name="model">ir.attachment.dms</field>
+        <field name="arch" type="xml">
+            <tree string="Attachment" editable="bottom" create="false" delete="false">
+                <field name="selectable_ok"/>
+                <field name="name"/>
+                <field name="owner"/>
+            </tree>
+        </field>
     </record>
 
   </data>


### PR DESCRIPTION
Port of https://code.launchpad.net/~savoirfairelinux-openerp/knowledge-addons/cmis_read/+merge/212260 by @ehdem 

**Depends on #6**

Add cmis_read; It allows to use the CMIS backend to search in the DMS repository
and attach documents to OpenERP records.
## LP reviews
- @max3903: Approve on 2014-06-19 
- @bwrsandman: Approve on 2014-06-19
- @guewen:
  
  > Hi,
  > It seems nice.
  > I left a few comments in the diff. I won't really block on them but you should have a look.
