### PR TITLE
[FIX][document_url] Consistent styling.

### DIFF
--- a/document_url/static/src/css/url.css
+++ b/document_url/static/src/css/url.css
@@ -1,3 +1,0 @@
-.oe_url_attachment{
-    padding: 3px 20px;
-}

--- a/document_url/static/src/xml/url.xml
+++ b/document_url/static/src/xml/url.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 <t t-name="AddUrlDocumentItem">
-     <li class="oe_sidebar_add_url"><span class="oe_url_attachment">Add URL...</span></li>
+    <li class="oe_sidebar_add_url">
+        <a class="oe_file_attachment">Add URL...</a>
+    </li>
 </t>
 </templates>

--- a/document_url/view/document_url_view.xml
+++ b/document_url/view/document_url_view.xml
@@ -4,7 +4,6 @@
 
         <template id="assets_backend" name="google_drive assets" inherit_id="web.assets_backend">
             <xpath expr="." position="inside">
-                <link rel="stylesheet" href="/document_url/static/src/css/url.css" type="text/css"/>
                 <script type="text/javascript" src="/document_url/static/src/js/url.js"></script>
             </xpath>
         </template>


### PR DESCRIPTION
Without this patch, when you hover on the menu item, its background color does not change, and its cursor is a text one:
![consejo emergente_002](https://cloud.githubusercontent.com/assets/973709/18955988/06951126-865a-11e6-960d-b24bebdc2840.jpg)

With this patch, the menu item styling matches those available in all surrounding menus:
![consejo emergente_003](https://cloud.githubusercontent.com/assets/973709/18956013/20f39a10-865a-11e6-9f34-0fa337963cf0.jpg)

@Tecnativa
