### PR TITLE
[9.0][FIX][knowledge] remove reference to category 'base.module_category_knowledge_management'

### DIFF
--- a/knowledge/__openerp__.py
+++ b/knowledge/__openerp__.py
@@ -27,6 +27,7 @@
     "license": "AGPL-3",
     "website": "https://www.odoo.com",
     "data": [
+        "data/knowledge_data.xml"
         "security/knowledge_security.xml",
         "security/ir.model.access.csv",
         "views/knowledge.xml",

--- a/knowledge/__openerp__.py
+++ b/knowledge/__openerp__.py
@@ -27,7 +27,7 @@
     "license": "AGPL-3",
     "website": "https://www.odoo.com",
     "data": [
-        "data/knowledge_data.xml"
+        "data/knowledge_data.xml",
         "security/knowledge_security.xml",
         "security/ir.model.access.csv",
         "views/knowledge.xml",

--- a/knowledge/data/knowledge_data.xml
+++ b/knowledge/data/knowledge_data.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+        <data>
+                <record model="ir.module.category" id="module_category_knowledge_management">
+                    <field name="name">Knowledge</field>
+                    <field name="description">Lets you install addons geared towards sharing knowledge with and between your employees.</field>
+                    <field name="sequence">4</field>
+                </record>
+        </data>
+</odoo>

--- a/knowledge/security/knowledge_security.xml
+++ b/knowledge/security/knowledge_security.xml
@@ -4,7 +4,6 @@
 
     <record id="base.group_document_user" model="res.groups">
         <field name="name">User</field>
-        <field name="category_id" ref="base.module_category_knowledge_management"/>
         <field name="users" eval="[(4, ref('base.user_root'))]"/>
     </record>
 

--- a/knowledge/security/knowledge_security.xml
+++ b/knowledge/security/knowledge_security.xml
@@ -4,6 +4,7 @@
 
     <record id="base.group_document_user" model="res.groups">
         <field name="name">User</field>
+        <field name="category_id" ref="module_category_knowledge_management"/>
         <field name="users" eval="[(4, ref('base.user_root'))]"/>
     </record>
 


### PR DESCRIPTION
base.module_category_knowledge_management no longer exists in v9.

During a migration from 8.0 to 9.0 we're getting the error 'External ID not found in the system'.