### PR TITLE
[NEW] document_type module

### DIFF
--- a/document_type/README.rst
+++ b/document_type/README.rst
@@ -51,6 +51,11 @@ Contributors
 
 * Leonardo Donelli @ MONK Software (leonardo.donelli@monksoftware.it)
 
+Acknowledgements
+----------------
+
+* Thanks to gingitsune for showing me a simple way to open a 'Save and Close' dialog
+
 Maintainer
 ----------
 

--- a/document_type/README.rst
+++ b/document_type/README.rst
@@ -42,6 +42,11 @@ knowledge/issues/new?body=module:%20
 knowledge%0Aversion:%20
 9.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
 
+TODO
+====
+
+* Show document type in the attachment list in the sidebar, and maybe order and group by those?
+
 
 Credits
 =======

--- a/document_type/README.rst
+++ b/document_type/README.rst
@@ -23,7 +23,7 @@ To use this module, you need to:
 
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
    :alt: Try me on Runbot
-   :target: https://runbot.odoo-community.org/runbot/repo/118/9.0
+   :target: https://runbot.odoo-community.org/runbot/repo/118/10.0
 
 
 Bug Tracker

--- a/document_type/README.rst
+++ b/document_type/README.rst
@@ -1,0 +1,67 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+==============
+Document Types
+==============
+
+Define type of documents per model, and choose what document you are uploading
+when attaching a file to a record.
+
+Installation
+============
+
+* None
+
+Configuration
+=============
+
+* None
+
+Usage
+=====
+
+To use this module, you need to:
+
+* Go to Knowledge / Configuration / Document types and configure your document types
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/repo/118/9.0
+
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues <https://github.com/OCA/
+knowledge/issues>`_.
+In case of trouble, please check there if your issue has already been reported.
+If you spotted it first, help us smashing it by providing a detailed and welcomed feedback `here <https://github.com/OCA/
+knowledge/issues/new?body=module:%20
+knowledge%0Aversion:%20
+9.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+
+
+Credits
+=======
+
+Contributors
+------------
+
+* Leonardo Donelli @ MONK Software (leonardo.donelli@monksoftware.it)
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/document_type/README.rst
+++ b/document_type/README.rst
@@ -9,15 +9,6 @@ Document Types
 Define type of documents per model, and choose what document you are uploading
 when attaching a file to a record.
 
-Installation
-============
-
-* None
-
-Configuration
-=============
-
-* None
 
 Usage
 =====
@@ -25,6 +16,10 @@ Usage
 To use this module, you need to:
 
 * Go to Knowledge / Configuration / Document types and configure your document types
+* Every time you attach a document using the 'Attachment' menu in the sidebar,
+  a popup will open allowing you to set attachment name, description and type;
+  according to the types defined for that model.
+
 
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
    :alt: Try me on Runbot

--- a/document_type/__init__.py
+++ b/document_type/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/document_type/__init__.py
+++ b/document_type/__init__.py
@@ -1,1 +1,4 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 MONK Software
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 from . import models

--- a/document_type/__manifest__.py
+++ b/document_type/__manifest__.py
@@ -13,6 +13,7 @@
         'views/document_type.xml',
         'views/attachment.xml',
         'templates/web.xml',
+        'security/ir.model.access.csv',
     ],
     "installable": True,
     "auto_install": False,

--- a/document_type/__manifest__.py
+++ b/document_type/__manifest__.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 MONK Software
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+{
+    "name": "Document Types"
+    "version": "10.0.1.0.0",
+    "author": "MONK Software, Odoo Community Association (OCA)",
+    "category": "Knowledge",
+    "license": "AGPL-3",
+    "website": "https://odoo-community.org/",
+    "depends": ["knowledge"],
+    "data": [],
+    'installable': True,
+    "auto_install": False,
+}

--- a/document_type/__manifest__.py
+++ b/document_type/__manifest__.py
@@ -2,14 +2,18 @@
 # Copyright 2016 MONK Software
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
-    "name": "Document Types"
+    "name": "Document Types",
     "version": "10.0.1.0.0",
     "author": "MONK Software, Odoo Community Association (OCA)",
     "category": "Knowledge",
     "license": "AGPL-3",
     "website": "https://odoo-community.org/",
-    "depends": ["knowledge"],
-    "data": [],
-    'installable': True,
+    "depends": ["document", "knowledge"],
+    "data": [
+        'views/document_type.xml',
+        'views/attachment.xml',
+        'templates/web.xml',
+    ],
+    "installable": True,
     "auto_install": False,
 }

--- a/document_type/__manifest__.py
+++ b/document_type/__manifest__.py
@@ -4,10 +4,14 @@
 {
     "name": "Document Types",
     "version": "10.0.1.0.0",
-    "author": "MONK Software, Odoo Community Association (OCA)",
+    "development_status": "Beta",
     "category": "Knowledge",
+    "website": "https://github.com/OCA/knowledge",
+    "author": "MONK Software, Odoo Community Association (OCA)",
     "license": "AGPL-3",
-    "website": "https://odoo-community.org/",
+    "application": False,
+    "installable": True,
+    "auto_install": False,
     "depends": ["document", "knowledge"],
     "data": [
         'views/document_type.xml',
@@ -15,6 +19,4 @@
         'templates/web.xml',
         'security/ir.model.access.csv',
     ],
-    "installable": True,
-    "auto_install": False,
 }

--- a/document_type/models/__init__.py
+++ b/document_type/models/__init__.py
@@ -1,0 +1,1 @@
+from . import document_type

--- a/document_type/models/__init__.py
+++ b/document_type/models/__init__.py
@@ -1,1 +1,4 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 MONK Software
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 from . import document_type

--- a/document_type/models/document_type.py
+++ b/document_type/models/document_type.py
@@ -1,0 +1,18 @@
+from odoo import fields, models
+
+
+class DocumentType(models.Model):
+    _name = 'document.type'
+    _description = 'Document Type'
+
+    name = fields.Char(required=True)
+    ir_model_id = fields.Many2one('ir.model', string='Object')
+    document_ids = fields.One2many(
+        'ir.attachment', 'document_type_id', string='Documents')
+
+
+class IrAttachment(models.Model):
+    _inherit = 'ir.attachment'
+
+    document_type_id = fields.Many2one(
+        'document.type', string='Document Type')

--- a/document_type/models/document_type.py
+++ b/document_type/models/document_type.py
@@ -9,6 +9,11 @@ class DocumentType(models.Model):
     ir_model_id = fields.Many2one('ir.model', string='Object')
     document_ids = fields.One2many(
         'ir.attachment', 'document_type_id', string='Documents')
+    documents_count = fields.Integer(compute='_compute_documents_count')
+
+    def _compute_documents_count(self):
+        for record in self:
+            record.documents_count = len(record.document_ids)
 
 
 class IrAttachment(models.Model):

--- a/document_type/models/document_type.py
+++ b/document_type/models/document_type.py
@@ -15,4 +15,5 @@ class IrAttachment(models.Model):
     _inherit = 'ir.attachment'
 
     document_type_id = fields.Many2one(
-        'document.type', string='Document Type')
+        'document.type', string='Document Type',
+        domain='[("ir_model_id.model", "=", res_model)]')

--- a/document_type/models/document_type.py
+++ b/document_type/models/document_type.py
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 MONK Software
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 from odoo import fields, models
 
 

--- a/document_type/security/ir.model.access.csv
+++ b/document_type/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+document_type_all,document.type.all,model_document_type,,1,0,0,0
+document_type_manager,document.type.document.manager,model_document_type,knowledge.group_document_manager,1,1,1,1

--- a/document_type/static/src/js/sidebar.js
+++ b/document_type/static/src/js/sidebar.js
@@ -1,3 +1,6 @@
+/* Copyright 2018 MONK Software
+ * License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). */
+
 odoo.define('document_type.sidebar', function(require) {
     "use strict";
 

--- a/document_type/static/src/js/sidebar.js
+++ b/document_type/static/src/js/sidebar.js
@@ -1,0 +1,40 @@
+odoo.define('document_type.sidebar', function(require) {
+    "use strict";
+
+    var core = require('web.core');
+    var form_common = require('web.form_common');
+    var Sidebar = require('web.Sidebar');
+    var Dialog = require('web.Dialog');
+    var Model = require('web.Model');
+
+    var _t = core._t;
+
+    Sidebar.include({
+
+        do_attachement_update: function(dataset, model_id, args) {
+            var self = this;
+            // if args is defined, a new attachment has been added
+            if (args && !args[0].error) {
+                var pop = new form_common.FormViewDialog(self, {
+                    res_model: 'ir.attachment',
+                    res_id: args[0].id,
+                    title: _t('Set attachment details'),
+                    view_id: self.attachment_upload_view_id
+                }).open();
+            }
+            this._super.apply(this, arguments);
+        },
+
+        start: function() {
+            var res = this._super.apply(this, arguments);
+            var self = this;
+            new Model('ir.model.data')
+                .call('xmlid_to_res_id', ['document_type.ir_attachment_view_form_upload'])
+                .then(function(view_id) {
+                    self.attachment_upload_view_id = view_id;
+                });
+        }
+
+    });
+
+});

--- a/document_type/templates/web.xml
+++ b/document_type/templates/web.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+  <template id="assets_backend" name="document_type backend assets" inherit_id="web.assets_backend">
+    <xpath expr="." position="inside">
+      <script type="text/javascript" src="/document_type/static/src/js/sidebar.js"></script>
+    </xpath>
+  </template>
+
+</odoo>

--- a/document_type/templates/web.xml
+++ b/document_type/templates/web.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2018 MONK Software
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
 <odoo>
 
   <template id="assets_backend" name="document_type backend assets" inherit_id="web.assets_backend">

--- a/document_type/views/attachment.xml
+++ b/document_type/views/attachment.xml
@@ -11,7 +11,9 @@
         <sheet>
           <group>
             <field name="name"/>
-            <field name="document_type_id"/>
+            <!-- Needed for the automatic domain on document_type_id -->
+            <field name="res_model" invisible="True"/>
+            <field name="document_type_id" options="{'no_create': True}"/>
             <field name="description"/>
           </group>
         </sheet>

--- a/document_type/views/attachment.xml
+++ b/document_type/views/attachment.xml
@@ -21,6 +21,20 @@
     </field>
   </record>
 
+  <record id="ir_attachment_view_search_document_type" model="ir.ui.view">
+    <field name="name"></field>
+    <field name="model">ir.attachment</field>
+    <field name="inherit_id" ref="base.view_attachment_search"/>
+    <field name="arch" type="xml">
+      <search position="inside">
+        <field name="document_type_id"/>
+      </search>
+      <xpath expr="//group" position="inside">
+        <filter name="group_by_document_type" string="Document Type" domain="[]" context="{'group_by': 'document_type_id'}"/>
+      </xpath>
+    </field>
+  </record>
+
   <record id="ir_attachment_action_upload_type" model="ir.actions.act_window">
     <field name="name">Attachment upload typle selection action</field>
     <field name="res_model">ir.attachment</field>

--- a/document_type/views/attachment.xml
+++ b/document_type/views/attachment.xml
@@ -21,6 +21,17 @@
     </field>
   </record>
 
+  <record id="ir_attachment_view_form_document_type" model="ir.ui.view">
+    <field name="name">Attachment form view: add document type</field>
+    <field name="model">ir.attachment</field>
+    <field name="inherit_id" ref="base.view_attachment_form"/>
+    <field name="arch" type="xml">
+      <field name="type" position="after">
+        <field name="document_type_id"/>
+      </field>
+    </field>
+  </record>
+
   <record id="ir_attachment_view_search_document_type" model="ir.ui.view">
     <field name="name">Attachment search view: add document type filter and groupby</field>
     <field name="model">ir.attachment</field>

--- a/document_type/views/attachment.xml
+++ b/document_type/views/attachment.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2018 MONK Software
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+
 <odoo>
 
   <record id="ir_attachment_view_form_upload" model="ir.ui.view">

--- a/document_type/views/attachment.xml
+++ b/document_type/views/attachment.xml
@@ -22,7 +22,7 @@
   </record>
 
   <record id="ir_attachment_view_search_document_type" model="ir.ui.view">
-    <field name="name"></field>
+    <field name="name">Attachment search view: add document type filter and groupby</field>
     <field name="model">ir.attachment</field>
     <field name="inherit_id" ref="base.view_attachment_search"/>
     <field name="arch" type="xml">

--- a/document_type/views/attachment.xml
+++ b/document_type/views/attachment.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+  <record id="ir_attachment_view_form_upload" model="ir.ui.view">
+    <field name="name">Attachment form view for type selection after upload</field>
+    <field name="model">ir.attachment</field>
+    <!-- higher priority needed to make sure this isn't used as default form view -->
+    <field name="priority" eval="32"/>
+    <field name="arch" type="xml">
+      <form create="false">
+        <sheet>
+          <group>
+            <field name="name"/>
+            <field name="document_type_id"/>
+            <field name="description"/>
+          </group>
+        </sheet>
+      </form>
+    </field>
+  </record>
+
+  <record id="ir_attachment_action_upload_type" model="ir.actions.act_window">
+    <field name="name">Attachment upload typle selection action</field>
+    <field name="res_model">ir.attachment</field>
+    <field name="view_mode">form</field>
+    <field name="view_id" ref="ir_attachment_view_form_upload"/>
+    <field name="target">new</field>
+  </record>
+
+</odoo>

--- a/document_type/views/document_type.xml
+++ b/document_type/views/document_type.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+  <record id="document_type_action_main" model="ir.actions.act_window">
+    <field name="name">Document Types</field>
+    <field name="res_model">document.type</field>
+    <field name="view_mode">tree,form</field>
+  </record>
+
+  <record id="document_type_view_form" model="ir.ui.view">
+    <field name="name">Document types list view</field>
+    <field name="model">document.type</field>
+    <field name="arch" type="xml">
+      <form>
+        <sheet>
+          <group>
+            <field name="name"/>
+            <field name="ir_model_id"/>
+          </group>
+        </sheet>
+      </form>
+    </field>
+  </record>
+
+  <record id="document_type_view_tree" model="ir.ui.view">
+    <field name="name">Document types list view</field>
+    <field name="model">document.type</field>
+    <field name="arch" type="xml">
+      <tree>
+        <field name="name"/>
+        <field name="ir_model_id"/>
+      </tree>
+    </field>
+  </record>
+
+  <menuitem
+      id="document_type_menu"
+      name="Document Types"
+      action="document_type_action_main"
+      parent="knowledge.menu_document_configuration"/>
+
+</odoo>

--- a/document_type/views/document_type.xml
+++ b/document_type/views/document_type.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2018 MONK Software
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+
 <odoo>
 
   <record id="document_type_action_main" model="ir.actions.act_window">

--- a/document_type/views/document_type.xml
+++ b/document_type/views/document_type.xml
@@ -13,6 +13,11 @@
     <field name="arch" type="xml">
       <form>
         <sheet>
+          <div class="oe_button_box" name="button_box">
+			      <button name="documents" class="oe_stat_button" icon="fa-book">
+              <field name="documents_count" string="Documents" widget="statinfo"/>
+			      </button>
+          </div>
           <group>
             <field name="name"/>
             <field name="ir_model_id"/>

--- a/document_type/views/document_type.xml
+++ b/document_type/views/document_type.xml
@@ -7,6 +7,14 @@
     <field name="view_mode">tree,form</field>
   </record>
 
+  <record id="ir_attachment_action_document_type" model="ir.actions.act_window">
+    <field name="name">Documents</field>
+    <field name="res_model">ir.attachment</field>
+    <field name="view_type">form</field>
+    <field name="view_mode">tree,form</field>
+    <field name="context">{'search_default_document_type_id': [active_id], 'default_document_type_id': active_id}</field>
+  </record>
+
   <record id="document_type_view_form" model="ir.ui.view">
     <field name="name">Document types list view</field>
     <field name="model">document.type</field>
@@ -14,7 +22,7 @@
       <form>
         <sheet>
           <div class="oe_button_box" name="button_box">
-			      <button name="documents" class="oe_stat_button" icon="fa-book">
+			      <button name="%(ir_attachment_action_document_type)d" type="action" class="oe_stat_button" icon="fa-book">
               <field name="documents_count" string="Documents" widget="statinfo"/>
 			      </button>
           </div>

--- a/knowledge/__manifest__.py
+++ b/knowledge/__manifest__.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     "name": "Knowledge Management System",
-    "version": "10.0.1.0.0",
+    "version": "10.0.1.1.0",
     "author": "OpenERP SA, MONK Software, Odoo Community Association (OCA)",
     "category": "Knowledge",
     "license": "AGPL-3",

--- a/knowledge/security/knowledge_security.xml
+++ b/knowledge/security/knowledge_security.xml
@@ -7,4 +7,12 @@
     <field name="users" eval="[(4, ref('base.user_root'))]"/>
   </record>
 
+  <record id="group_document_manager" model="res.groups">
+    <field name="name">Knowledge manager</field>
+    <field name="comment">Knowledge managers can define document types</field>
+    <field name="category_id" ref="module_category_knowledge"/>
+    <field name="implied_ids" eval="[(4, ref('base.group_document_user'))]"/>
+    <field name="users" eval="[(4, ref('base.user_root'))]"/>
+  </record>
+
 </odoo>

--- a/knowledge/security/knowledge_security.xml
+++ b/knowledge/security/knowledge_security.xml
@@ -11,7 +11,7 @@
     <field name="name">Knowledge manager</field>
     <field name="comment">Knowledge managers can define document types</field>
     <field name="category_id" ref="module_category_knowledge"/>
-    <field name="implied_ids" eval="[(4, ref('base.group_document_user'))]"/>
+    <field name="implied_ids" eval="[(4, ref('knowledge.group_document_user'))]"/>
     <field name="users" eval="[(4, ref('base.user_root'))]"/>
   </record>
 

--- a/knowledge/views/knowledge.xml
+++ b/knowledge/views/knowledge.xml
@@ -13,6 +13,7 @@
       id="menu_document_configuration"
       name="Configuration"
       parent="menu_document"
+      groups="group_document_manager"
       sequence="50"/>
 
 </odoo>


### PR DESCRIPTION
Define type of documents per model, and choose what document you are uploading
when attaching a file to a record.

* Go to Knowledge / Configuration / Document types and configure your document types
* Every time you attach a document using the 'Attachment' menu in the sidebar,
  a popup will open allowing you to set attachment name, description and type;
  according to the types defined for that model.
* In the document list, you can filter and/or groupby by document type.
