### PR TITLE
[NEW] New module: attachment_attach_non_editable

### DIFF
--- a/attachment_attach_non_editable/README.rst
+++ b/attachment_attach_non_editable/README.rst
@@ -1,0 +1,56 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+===============================
+Force enable attachments upload
+===============================
+
+In odoo, by default, you can't add attachments to a record if the form view
+is set as not editable (``edit='false'`` in the form tag)
+
+This module adds a new form view attribute, ``attach=``, which lets you
+enable attachment uploads even in non-editable forms.
+
+Usage
+=====
+
+Add the ``attach=true`` attribute to the form view tag which of uneditable views
+(normal editable views already allow attaching a document and there is no need
+for this attribute).
+
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues <https://github.com/OCA/
+knowledge/issues>`_.
+In case of trouble, please check there if your issue has already been reported.
+If you spotted it first, help us smashing it by providing a detailed and welcomed feedback `here <https://github.com/OCA/
+knowledge/issues/new?body=module:%20
+attachment_force_attach%0Aversion:%20
+10.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+
+
+Credits
+=======
+
+Contributors
+------------
+
+* Leonardo Donelli @ MONK Software (leonardo.donelli@monksoftware.it)
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/attachment_attach_non_editable/README.rst
+++ b/attachment_attach_non_editable/README.rst
@@ -12,12 +12,20 @@ is set as not editable (``edit='false'`` in the form tag)
 This module adds a new form view attribute, ``attach=``, which lets you
 enable attachment uploads even in non-editable forms.
 
+Keep in mind: users still won't be able to attach documents
+to records they don't have write access to (according to ACL and record rules);
+this module does not bypass odoo' security rules!
+
 Usage
 =====
 
-Add the ``attach=true`` attribute to the form view tag which of uneditable views
+Add the ``attach="true"`` attribute to the form view tag which of uneditable views
 (normal editable views already allow attaching a document and there is no need
 for this attribute).
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/118/10.0
 
 
 Bug Tracker

--- a/attachment_attach_non_editable/__manifest__.py
+++ b/attachment_attach_non_editable/__manifest__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 MONK Software
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+{
+    "name": "Force enable attachments",
+    "version": "10.0.1.0.0",
+    "author": "MONK Software, Odoo Community Association (OCA)",
+    "category": "Knowledge",
+    "license": "AGPL-3",
+    "website": "https://odoo-community.org/",
+    "depends": ["document"],
+    "data": [
+        'templates/web.xml',
+    ],
+    "qweb": [
+        'static/src/xml/sidebar.xml',
+    ],
+    "installable": True,
+    "auto_install": False,
+}

--- a/attachment_attach_non_editable/static/src/js/sidebar.js
+++ b/attachment_attach_non_editable/static/src/js/sidebar.js
@@ -1,0 +1,19 @@
+odoo.define('attachment_attach_non_editable.sidebar', function(require) {
+    "use strict";
+
+    var core = require('web.core');
+    var Sidebar = require('web.Sidebar');
+
+
+    Sidebar.include({
+
+        init: function(parent, options) {
+            this._super.apply(this, arguments);
+            if (parent.is_action_enabled('attach')) {
+                this.options.attachable = true;
+            }
+        }
+
+    });
+
+});

--- a/attachment_attach_non_editable/static/src/xml/sidebar.xml
+++ b/attachment_attach_non_editable/static/src/xml/sidebar.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+
+  <t t-extend="Sidebar">
+    <t t-jquery=".o_sidebar_add_attachment">
+      this.attr('t-if', "section.name == 'files' and (widget.options.editable or widget.options.attachable)");
+    </t>
+  </t>
+
+</templates>

--- a/attachment_attach_non_editable/templates/web.xml
+++ b/attachment_attach_non_editable/templates/web.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+  <template id="assets_backend" name="document_type backend assets" inherit_id="web.assets_backend">
+    <xpath expr="." position="inside">
+      <script type="text/javascript" src="/attachment_attach_non_editable/static/src/js/sidebar.js"></script>
+    </xpath>
+  </template>
+
+</odoo>


### PR DESCRIPTION
In odoo, by default, you can't add attachments to a record if the form view
is set as not editable (``edit='false'`` in the form tag)

This module adds a new form view attribute, ``attach=``, which lets you
enable attachment uploads even in non-editable forms.