### PR TITLE
document_url: Fix inclusion of unknown field 'user_id'

### DIFF
--- a/document_url/__openerp__.py
+++ b/document_url/__openerp__.py
@@ -4,7 +4,7 @@
 # © 2016 ACSONE SA/NV (<http://acsone.eu>)
 {
     'name': 'URL attachment',
-    'version': '9.0.2.0.1',
+    'version': '9.0.2.0.2',
     'category': 'Tools',
     'author': "Tecnativa,"
               "Odoo Community Association (OCA)",

--- a/document_url/wizard/document_url.py
+++ b/document_url/wizard/document_url.py
@@ -34,7 +34,6 @@ class AddUrlWizard(orm.TransientModel):
                     'name': form.name,
                     'type': 'url',
                     'url': url.geturl(),
-                    'user_id': uid,
                     'res_id': active_id,
                     'res_model': context['active_model'],
                 }


### PR DESCRIPTION
Remove 'user_id' key in a dictionary prepared to
create an 'ir.attachment' object, because it's
an unknown field for that model

cc @Tecnativa