### PR TITLE
document_url: Fix inclusion of unknown field 'user_id'

### DIFF
--- a/document_url/wizard/document_url.py
+++ b/document_url/wizard/document_url.py
@@ -34,7 +34,6 @@ class AddUrlWizard(orm.TransientModel):
                     'name': form.name,
                     'type': 'url',
                     'url': url.geturl(),
-                    'user_id': uid,
                     'res_id': active_id,
                     'res_model': context['active_model'],
                 }


### PR DESCRIPTION
Remove 'user_id' key in a dictionary prepared to
create an 'ir.attachment' object, because it's
an unknown field for that model

cc @Tecnativa