### PR TITLE
[11.0]Remove unrequired style color

### DIFF
--- a/document_url/static/src/less/url.less
+++ b/document_url/static/src/less/url.less
@@ -1,7 +1,6 @@
 .o_cp_sidebar {
     .o_sidebar_add_url span {
         padding: 3px 25px;
-        color: @btn-default-color;
     }
     .o_sidebar_add_url:hover {
         background-color: @table-bg-hover;


### PR DESCRIPTION
It shows the element in white color over a white background
![deepin-screen-recorder_select area_20181211164619](https://user-images.githubusercontent.com/5034215/49804841-b03aca80-fd64-11e8-88cd-9f204138014d.gif)
.