### PR TITLE
[11.0][FIX] attachment_preview: attachment not present

### DIFF
--- a/attachment_preview/__manifest__.py
+++ b/attachment_preview/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "Preview attachments",
-    "version": "11.0.1.2.0",
+    "version": "11.0.1.2.1",
     "author": "Therp BV,"
               "Onestein,"
               "Odoo Community Association (OCA)",

--- a/attachment_preview/models/ir_attachment.py
+++ b/attachment_preview/models/ir_attachment.py
@@ -41,7 +41,7 @@ class IrAttachment(models.Model):
         ids_to_browse = [_id for _id in ids_to_browse if _id not in result]
         for this in self.env[model].with_context(
                 bin_size=True).browse(ids_to_browse):
-            if this[binary_field] is None:
+            if not this[binary_field]:
                 result[this.id] = False
                 continue
             try:


### PR DESCRIPTION
This PR fixes the following error:

```
Error:
Odoo Server Error

Traceback (most recent call last):
  File "/home/onestein/Pycharm/Gitlab/odoo-11.0/src/oca/attachment_preview/models/ir_attachment.py", line 48, in get_binary_extension
    import magic
ModuleNotFoundError: No module named 'magic'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/onestein/Pycharm/Gitlab/odoo-11.0/src/odoo-11.0/odoo/http.py", line 650, in _handle_exception
    try:
  File "/home/onestein/Pycharm/Gitlab/odoo-11.0/src/odoo-11.0/odoo/http.py", line 310, in _handle_exception
    raise pycompat.reraise(type(exception), exception, sys.exc_info()[2])
  File "/home/onestein/Pycharm/Gitlab/odoo-11.0/src/odoo-11.0/odoo/tools/pycompat.py", line 87, in reraise
    raise value
  File "/home/onestein/Pycharm/Gitlab/odoo-11.0/src/odoo-11.0/odoo/http.py", line 692, in dispatch
  File "/home/onestein/Pycharm/Gitlab/odoo-11.0/src/odoo-11.0/odoo/http.py", line 342, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "/home/onestein/Pycharm/Gitlab/odoo-11.0/src/odoo-11.0/odoo/service/model.py", line 97, in wrapper
    return f(dbname, *args, **kwargs)
  File "/home/onestein/Pycharm/Gitlab/odoo-11.0/src/odoo-11.0/odoo/http.py", line 335, in checked_call
    result = self.endpoint(*a, **kw)
  File "/home/onestein/Pycharm/Gitlab/odoo-11.0/src/odoo-11.0/odoo/http.py", line 936, in __call__
    def __call__(self, *args, **kw):
  File "/home/onestein/Pycharm/Gitlab/odoo-11.0/src/odoo-11.0/odoo/http.py", line 515, in response_wrap
    response = f(*args, **kw)
  File "/home/onestein/Pycharm/Gitlab/odoo-11.0/src/odoo-11.0/addons/web/controllers/main.py", line 934, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "/home/onestein/Pycharm/Gitlab/odoo-11.0/src/odoo-11.0/addons/web/controllers/main.py", line 926, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/home/onestein/Pycharm/Gitlab/odoo-11.0/src/odoo-11.0/odoo/api.py", line 687, in call_kw
    return call_kw_model(method, model, args, kwargs)
  File "/home/onestein/Pycharm/Gitlab/odoo-11.0/src/odoo-11.0/odoo/api.py", line 672, in call_kw_model
    result = method(recs, *args, **kwargs)
  File "/home/onestein/Pycharm/Gitlab/odoo-11.0/src/oca/attachment_preview/models/ir_attachment.py", line 62, in get_binary_extension
    'data:;base64,' + this[binary_field], strict=False)
TypeError: must be str, not bool
```

I was able to reproduce that error by following those steps:

- make a database backup **without filestore** and restore it again;
- log in the new dababase and activate the debug mode;
- go to Settings->Technical->User Interface->Menu Items;
- Open the form view for each record one by one, until you get the stacktrace above.

The stacktrace above is raised when in [this line](https://github.com/OCA/knowledge/blob/11.0/attachment_preview/models/ir_attachment.py#L62) `this[binary_field]` is equal to `False`. In facts the actual code only handle correctly the case: `this[binary_field]` is equal to `None` (see [lines](https://github.com/OCA/knowledge/blob/11.0/attachment_preview/models/ir_attachment.py#L44-L46)).

The fix in this PR consists of treating the case `this[binary_field]` equal to `False` the same way as `this[binary_field]` equal to `None`.
