### PR TITLE
[DEL] document_page: remove deprecated icon key from menu item

### DIFF
--- a/document_page/wizard/document_page_create_menu.py
+++ b/document_page/wizard/document_page_create_menu.py
@@ -65,7 +65,6 @@ class DocumentPageCreateMenu(models.TransientModel):
         menu_id = obj_menu.sudo().create({
             'name': data.menu_name,
             'parent_id': data.menu_parent_id.id,
-            'icon': 'STOCK_DIALOG_QUESTION',
             'action': 'ir.actions.act_window,' + str(action_id.id),
         })
         page.write({'menu_id': menu_id.id})


### PR DESCRIPTION
the `icon` key is deprecated for a while already and this generates a warning in tests