### PR TITLE
[11.0][FIX] document_page: use document page view as default instead of category one.

### DIFF
--- a/document_page/__manifest__.py
+++ b/document_page/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     'name': 'Document Page',
-    'version': '11.0.2.3.0',
+    'version': '11.0.2.4.0',
     'category': 'Knowledge Management',
     'author': 'OpenERP SA, Odoo Community Association (OCA)',
     'images': [

--- a/document_page/views/document_page.xml
+++ b/document_page/views/document_page.xml
@@ -36,6 +36,7 @@
     <record id="view_wiki_form" model="ir.ui.view">
         <field name="name">document.page.form</field>
         <field name="model">document.page</field>
+        <field name="priority">10</field>
         <field name="arch" type="xml">
             <form string="Document Page">
                 <sheet>


### PR DESCRIPTION
This was specially annoying when accessing a document with planned activities from the topbar activities dropdown.

@Eficent 