### PR TITLE
[12.0] document_page:  fix links in category index

### DIFF
--- a/document_page/models/document_page.py
+++ b/document_page/models/document_page.py
@@ -101,6 +101,17 @@ class DocumentPage(models.Model):
         index=True,
         ondelete='cascade',
     )
+    backend_url = fields.Char(
+        string='Backend URL',
+        help='Use it to link resources univocally',
+        compute='_compute_backend_url',
+    )
+
+    @api.depends()
+    def _compute_backend_url(self):
+        tmpl = '/web#id={}&model=document.page&view_type=form'
+        for rec in self:
+            rec.backend_url = tmpl.format(rec.id)
 
     @api.constrains('parent_id')
     def _check_parent_id(self):
@@ -116,11 +127,12 @@ class DocumentPage(models.Model):
             index += ["<li>" + subpage._get_page_index() + "</li>"]
         r = ''
         if link:
-            r = '<a href="#id=%s">%s</a>' % (self.id, self.name)
+            r = '<a href="{}">{}</a>'.format(self.backend_url, self.name)
 
         if index:
             r += "<ul>" + "".join(index) + "</ul>"
         return r
+        
 
     @api.multi
     @api.depends('history_head')

--- a/document_page/readme/CONTRIBUTORS.rst
+++ b/document_page/readme/CONTRIBUTORS.rst
@@ -3,3 +3,4 @@
 * Iván Todorovich <ivan.todorovich@gmail.com>
 * Jose Maria Alzaga <jose.alzaga@aselcis.com>
 * Lois Rilo <lois.rilo@eficent.com>
+* Simone Orsi <simone.orsi@camptocamp.com>

--- a/document_page/tests/test_document_page.py
+++ b/document_page/tests/test_document_page.py
@@ -37,3 +37,13 @@ class TestDocumentPage(common.TransactionCase):
         })
         page.content = 'New content'
         self.assertIsNotNone(page.history_ids[0].diff)
+
+    def test_page_link(self):
+        page = self.page_obj.create({
+            'name': 'Test Page 3',
+            'content': 'Test content'
+        })
+        self.assertEqual(
+            page.backend_url,
+            '/web#id={}&model=document.page&view_type=form'.format(page.id)
+        )

--- a/document_page/tests/test_document_page.py
+++ b/document_page/tests/test_document_page.py
@@ -47,3 +47,11 @@ class TestDocumentPage(common.TransactionCase):
             page.backend_url,
             '/web#id={}&model=document.page&view_type=form'.format(page.id)
         )
+        menu = self.env.ref('knowledge.menu_document')
+        page.menu_id = menu
+        self.assertEqual(
+            page.backend_url,
+            '/web#id={}&model=document.page&view_type=form&action={}'.format(
+                page.id, menu.action.id
+            )
+        )


### PR DESCRIPTION
ATM  links are broken. They just use `#id`. Completely unusable.

The 1st commit fixes it by adding the model: the link now works.

Then, w/out an action, the link works but the context of the app is lost.
The 2nd commit tries to improve this by using the menu assigned to the specific page or it looks up in the page hierarchy until it finds one.
This implies that if you want a nice behavior you have to assign menu_id to all the categories when you set them up.

BTW I don't understand why the menu has been made not editable in some views.