### PR TITLE
[FIX] document_url: Always add attachment filename

### DIFF
--- a/document_url/__manifest__.py
+++ b/document_url/__manifest__.py
@@ -3,7 +3,7 @@
 # Copyright 2016 ACSONE SA/NV (<http://acsone.eu>)
 {
     'name': 'URL attachment',
-    'version': '12.0.1.0.0',
+    'version': '12.0.1.1.0',
     'category': 'Tools',
     'author': "Tecnativa,"
               "Odoo Community Association (OCA)",

--- a/document_url/migrations/12.0.1.1.0/pre-migrate.py
+++ b/document_url/migrations/12.0.1.1.0/pre-migrate.py
@@ -1,0 +1,10 @@
+# Copyright 2019 Tecnativa - Jairo Llopis
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+def migrate(cr, version):
+    """Stored URLs need to define a filename."""
+    cr.execute("""
+        UPDATE ir_attachment
+        SET filename = name
+        WHERE filename IS NULL AND type = 'url'
+    """)

--- a/document_url/tests/test_document_url.py
+++ b/document_url/tests/test_document_url.py
@@ -26,5 +26,6 @@ class TestDocumentUrl(common.TransactionCase):
             ('res_model', '=', 'res.users'),
             ('res_id', '=', self.env.ref('base.user_demo').id)
         ]
-        attachment_added_count = self.env['ir.attachment'].search_count(domain)
-        self.assertEqual(attachment_added_count, 1)
+        attachment_added = self.env['ir.attachment'].search(domain)
+        self.assertEqual(len(attachment_added), 1)
+        self.assertEqual(attachment_added.filename, 'Demo User (Website)')

--- a/document_url/wizard/document_url.py
+++ b/document_url/wizard/document_url.py
@@ -24,6 +24,7 @@ class AddUrlWizard(models.Model):
             for active_id in self.env.context.get('active_ids', []):
                 attachment = {
                     'name': form.name,
+                    'filename': form.name,
                     'type': 'url',
                     'url': url.geturl(),
                     'res_id': active_id,


### PR DESCRIPTION
In v12, if you browse to a record that has an URL attachment, you'll get an error because its `filename` will be `False` and that will make [this line][1] fail.

To avoid that problem:

1. A migration script ensures URL attachments always have a filename.
2. From now on, created URL attachments with this module will also have a filename.
3. The filename used is the name.

[1]: https://github.com/odoo/odoo/blob/66c5053a3d1f8cb456929453a62869c95eccf86a/addons/mail/static/src/xml/thread.xml#L506

@Tecnativa TT19555