### PR TITLE
[FIX] document_page: duplicate page with content

### DIFF
--- a/document_page/models/document_page.py
+++ b/document_page/models/document_page.py
@@ -37,6 +37,7 @@ class DocumentPage(models.Model):
         inverse='_inverse_content',
         search='_search_content',
         required=True,
+        copy=True,
     )
 
     # no-op computed field


### PR DESCRIPTION
Useless duplication operation because of the missing content field.

Fixes: #237