### PR TITLE
[FIX][13.0] retrive 12.0 behaviours in category creation without content

### DIFF
--- a/document_page/views/document_page_category.xml
+++ b/document_page/views/document_page_category.xml
@@ -38,6 +38,7 @@
                                 widget="html"
                                 class="oe_view_only"
                                 options='{"safe": True}'
+                                required="0"
                             />
                         </page>
                     </notebook>


### PR DESCRIPTION
The document.page content for category is required as in 12.0 but in IHM in 12.0 we can create a category without fill this field.

It's only one fix to retrive the same behaviour but investigation in the field definition and computation will be great

* to avoid  to add content (not save in the category creation)
![Peek 2020-05-25 16-03](https://user-images.githubusercontent.com/32262135/82883833-435cc580-9f43-11ea-909f-db58f8c4735d.gif)

* and create directly the category
![Peek 2020-05-26 11-27](https://user-images.githubusercontent.com/32262135/82884319-ddbd0900-9f43-11ea-936c-742826ee07e9.gif)
