### PR TITLE
[12.0][ADD] document_page: Add required fields to improve page_history

### DIFF
--- a/document_page/demo/document_page.xml
+++ b/document_page/demo/document_page.xml
@@ -8,6 +8,8 @@
 
         <record id="demo_category1" model="document.page">
             <field name="name">OpenERP Features</field>
+            <field name="draft_name">1.0</field>
+            <field name="draft_summary">Init</field>
             <field name="type">category</field>
             <field  name="template">
 Summary of the feature
@@ -24,6 +26,8 @@ Additional ressources
         <record id="demo_page1" model="document.page">
             <field name="name">OpenERP 6.1. Functional Demo</field>
             <field name="parent_id" ref="demo_category1"/>
+            <field name="draft_name">1.0</field>
+            <field name="draft_summary">Init</field>
             <field name="content">
 <![CDATA[
 <br>
@@ -53,6 +57,8 @@ company, with your clients and implement it now for your business.<br>
         <record id="demo_page2" model="document.page">
             <field name="name">Personalise Dashboards</field>
             <field name="parent_id" ref="demo_category1"/>
+            <field name="draft_name">1.0</field>
+            <field name="draft_summary">Init</field>
             <field name="content">
 <![CDATA[
 <br>
@@ -94,6 +100,8 @@ you change your mind there is a reset button to return to the default view.<br>
         <record id="demo_page3" model="document.page">
             <field name="name">Touchscreen Point of Sale</field>
             <field name="parent_id" ref="demo_category1"/>
+            <field name="draft_name">1.0</field>
+            <field name="draft_summary">Init</field>
             <field name="content">
 <![CDATA[
 <br>

--- a/document_page/readme/CONTRIBUTORS.rst
+++ b/document_page/readme/CONTRIBUTORS.rst
@@ -4,3 +4,7 @@
 * Jose Maria Alzaga <jose.alzaga@aselcis.com>
 * Lois Rilo <lois.rilo@eficent.com>
 * Simone Orsi <simone.orsi@camptocamp.com>
+
+* `Tecnativa <https://www.tecnativa.com>`_:
+
+  * Víctor Martínez

--- a/document_page/views/document_page.xml
+++ b/document_page/views/document_page.xml
@@ -57,15 +57,15 @@
                         <page name="info" string="Information">
                             <group>
                                 <group>
-                                    <field name="parent_id" string="Category" context="{'default_type':'category'}"/>
+                                    <field name="parent_id" string="Category" required="True" context="{'default_type':'category'}"/>
                                     <field name="company_id" groups="base.group_multi_company"/>
                                     <field name="content_uid"/>
                                     <field name="content_date"/>
                                     <field name="menu_id" readonly="1" attrs="{'invisible': [('menu_id','=',False)]}"/>
                                 </group>
                                 <group string="Revision" class="oe_edit_only">
-                                    <field name="draft_name" placeholder="Rev 01" class="oe_edit_only" />
-                                    <field name="draft_summary" placeholder="eg: Changed ... for ..." class="oe_edit_only" />
+                                    <field name="draft_name" placeholder="Rev 01" required="True" class="oe_edit_only" />
+                                    <field name="draft_summary" placeholder="eg: Changed ... for ..." required="True" class="oe_edit_only" />
                                 </group>
                             </group>
                         </page>

--- a/document_page/views/document_page_history.xml
+++ b/document_page/views/document_page_history.xml
@@ -23,8 +23,8 @@
         <field name="model">document.page.history</field>
         <field name="arch" type="xml">
             <search string="Document Page History">
-                <field name="page_id"/>
-                <field name="content"/>
+                <field name="page_id" required="True" />
+                <field name="content" required="True" />
                 <field name="create_uid"/>
                 <group expand="0" string="Group By...">
                     <filter name="group_by_author" string="Author" context="{'group_by':'create_uid'}" />


### PR DESCRIPTION
Add required fields (category, Revision name and revision summary) in `document_page` to improve page_history.

Related to: https://github.com/OCA/knowledge/pull/275 (13.0)

Please, @pedrobaeza and @joao-p-marques review it.

@Tecnativa TT26965