### PR TITLE
fix the visibility of the preview area

### DIFF
--- a/attachment_preview/static/src/scss/attachment_preview.scss
+++ b/attachment_preview/static/src/scss/attachment_preview.scss
@@ -32,6 +32,7 @@
     height: 100%;
     float: right;
     position: relative;
+    z-index: 999;
 
     > .attachment_preview_iframe {
         width: 100%;


### PR DESCRIPTION
This Commit fixed a visibility problem.

before: ![before](https://user-images.githubusercontent.com/17731016/103553038-26ab4780-4ead-11eb-82ed-b5a0fb680270.png)
after: ![after](https://user-images.githubusercontent.com/17731016/103553046-29a63800-4ead-11eb-9384-887bc7cfd946.png)
