### PR TITLE
[12.0][FIX] document_page_approval: Add rule to manager group users from history pages

### DIFF
--- a/document_page_approval/security/document_page_security.xml
+++ b/document_page_approval/security/document_page_security.xml
@@ -33,4 +33,15 @@
         <field name="perm_create" eval="True"/>
     </record>
 
+    <record model="ir.rule" id="rule_change_request_manager">
+        <field name="name">Change Request Manager</field>
+        <field name="model_id" ref="model_document_page_history"/>
+        <field name="groups" eval="[(6, 0, [ref('document_page.group_document_manager')])]"/>
+        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="perm_read" eval="True"/>
+        <field name="perm_write" eval="True"/>
+        <field name="perm_unlink" eval="True"/>
+        <field name="perm_create" eval="True"/>
+    </record>
+
 </odoo>


### PR DESCRIPTION
Add rule to manager group users from history pages.

Steps to reproduce:
- Create  Knowledge / Editor user
- Create change request from any page (requires approval).
- Create  Knowledge / Manager user
- Go to request previously created by "Editor user" and try to: "Cancel" and "Back to draft"

With these rule it's possible to access page history in draft state created by other user (not itself).
It's need to apply in 13.0.

Please @pedrobaeza and @joao-p-marques can you review it?

@Tecnativa TT29016
