### PR TITLE
[13.0][FIX] document_page_approval: Add rule to manager group users from history pages

### DIFF
--- a/document_page_approval/security/document_page_security.xml
+++ b/document_page_approval/security/document_page_security.xml
@@ -33,4 +33,17 @@
         <field name="perm_unlink" eval="True" />
         <field name="perm_create" eval="True" />
     </record>
+    <record model="ir.rule" id="rule_change_request_manager">
+        <field name="name">Change Request Manager</field>
+        <field name="model_id" ref="model_document_page_history" />
+        <field
+            name="groups"
+            eval="[(6, 0, [ref('document_page.group_document_manager')])]"
+        />
+        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="perm_read" eval="True" />
+        <field name="perm_write" eval="True" />
+        <field name="perm_unlink" eval="True" />
+        <field name="perm_create" eval="True" />
+    </record>
 </odoo>

--- a/document_page_approval/tests/test_document_page_approval.py
+++ b/document_page_approval/tests/test_document_page_approval.py
@@ -1,3 +1,4 @@
+from odoo.exceptions import AccessError
 from odoo.tests import common
 
 
@@ -22,6 +23,16 @@ class TestDocumentPageApproval(common.TransactionCase):
                 "login": "Test user 2",
                 "groups_id": [
                     (6, 0, [self.env.ref("base.group_user").id, self.approver_gid.id])
+                ],
+            }
+        )
+        self.manager_gid = self.env.ref("document_page.group_document_manager")
+        self.user_manager = self.env["res.users"].create(
+            {
+                "name": "Test document manager",
+                "login": "Test document manager",
+                "groups_id": [
+                    (6, 0, [self.env.ref("base.group_user").id, self.manager_gid.id])
                 ],
             }
         )
@@ -135,6 +146,35 @@ class TestDocumentPageApproval(common.TransactionCase):
         self.assertEqual(page.content, chreq.content)
         self.assertEqual(page.approved_date, chreq.approved_date)
         self.assertEqual(page.approved_uid, chreq.approved_uid)
+
+    def test_check_rules(self):
+        page = self.page2
+        # aprove everything
+        self.history_obj.search(
+            [("page_id", "=", page.id), ("state", "!=", "approved")]
+        ).action_approve()
+        # new change request from scrath
+        chreq = self.history_obj.create(
+            {
+                "page_id": page.id,
+                "summary": "Changed something",
+                "content": "New content",
+            }
+        )
+        self.assertEqual(chreq.state, "draft")
+        chreq.action_to_approve()
+        self.assertEqual(chreq.state, "to approve")
+        chreq.action_cancel()
+        self.assertEqual(chreq.state, "cancelled")
+        chreq.sudo().action_draft()
+        chreq.invalidate_cache()
+        with self.assertRaises(AccessError):
+            self.assertEqual(chreq.with_user(self.user2).state, "draft")
+        self.assertEqual(chreq.state, "draft")
+        chreq.invalidate_cache()
+        self.assertEqual(chreq.with_user(self.user_manager).state, "draft")
+        chreq.action_approve()
+        self.assertEqual(chreq.state, "approved")
 
     def test_get_approvers_guids(self):
         """Get approver guids."""


### PR DESCRIPTION
FWP from 12.0: https://github.com/OCA/knowledge/pull/290

Add rule to manager group users from history pages.

Steps to reproduce:
- Create  Knowledge / Editor user
- Create change request from any page (requires approval).
- Create  Knowledge / Manager user
- Go to request previously created by "Editor user" and try to: "Cancel" and "Back to draft"

With these rule it's possible to access page history in draft state created by other user (not itself).
It's need to apply in 13.0.

Please @pedrobaeza and @joao-p-marques can you review it?

@Tecnativa TT29016
