### PR TITLE
[12.0][FIX] document_page_approval: Delete diff in email_template to prevent errors in some cases

### DIFF
--- a/document_page_approval/data/email_template.xml
+++ b/document_page_approval/data/email_template.xml
@@ -26,11 +26,6 @@
 <p>${object.summary}</p>
 % endif
 
-<h3>Diff</h3>
-<div style="overflow-x:scroll; font-size:0.85em; margin-bottom:2em;">
-${object.diff|safe}
-</div>
-
 <p>Have a great day.</p>
 
 --<br/>


### PR DESCRIPTION
Delete diff in email_template to prevent errors in some cases.

If we added image in base64 inside content:
`<img src="data:image/png;base64,xxxxxx" />`
when Odoo try to render message and send try to create `ir.attachment` with `type=content` (it's not possible).

Please @joao-p-marques  and @chienandalu can you review it?

@Tecnativa TT29089