### PR TITLE
[FIX] attachment_preview: start needs to return a promise

### DIFF
--- a/attachment_preview/README.rst
+++ b/attachment_preview/README.rst
@@ -80,7 +80,7 @@ Authors
 Contributors
 ~~~~~~~~~~~~
 
-* Holger Brunn <hbrunn@therp.nl>
+* Holger Brunn <mail@hunki-enterprises.com>
 * Dennis Sluijk <d.sluijk@onestein.nl>
 
 Other credits

--- a/attachment_preview/readme/CONTRIBUTORS.rst
+++ b/attachment_preview/readme/CONTRIBUTORS.rst
@@ -1,2 +1,2 @@
-* Holger Brunn <hbrunn@therp.nl>
+* Holger Brunn <mail@hunki-enterprises.com>
 * Dennis Sluijk <d.sluijk@onestein.nl>

--- a/attachment_preview/static/src/js/attachment_preview.js
+++ b/attachment_preview/static/src/js/attachment_preview.js
@@ -328,8 +328,10 @@ odoo.define('attachment_preview', function (require) {
         },
 
         start: function () {
-            this._super.apply(this, arguments);
-            this.attachmentPreviewWidget.insertAfter(this.$el);
+            var self = this;
+            return this._super.apply(this, arguments).then(function () {
+                return self.attachmentPreviewWidget.insertAfter(self.$el);
+            });
         },
 
         _attachmentPreviewWidgetHidden: function () {


### PR DESCRIPTION
the current version breaks concurrency as start must return a promise: https://github.com/OCA/OCB/blob/12.0/addons/web/static/src/js/core/widget.js#L130

You can check the issue by clicking the 'Change document template' button on the general settings page, without this patch, this will fail.

This should be ported to 13 and 14 as it's wrong there too.