### PR TITLE
[12.0][FIX] document_page_reference: Reference unique constraint error on duplicate

### DIFF
--- a/document_page_reference/models/document_page.py
+++ b/document_page_reference/models/document_page.py
@@ -51,6 +51,16 @@ class DocumentPage(models.Model):
     )
     content_parsed = fields.Html(compute='_compute_content_parsed')
 
+    @api.multi
+    @api.returns('self', lambda value: value.id)
+    def copy(self, default=None):
+        self.ensure_one()
+        if default is None:
+            default = {}
+        if not default.get('reference'):
+            default.update(reference=_('%s_copy') % (self.reference))
+        return super(DocumentPage, self).copy(default)
+
     @api.depends('history_head')
     def _compute_content_parsed(self):
         for record in self:


### PR DESCRIPTION
Basic commit that add a `copy` overload to manage `reference` field that must stay unique.