### PR TITLE
[14.0][IMP] document_page: search by title only

### DIFF
--- a/document_page/views/document_page.xml
+++ b/document_page/views/document_page.xml
@@ -149,6 +149,7 @@
                 <field name="parent_id" />
                 <field name="create_uid" />
                 <field name="content_uid" />
+                <field name="name" string="Title" />
                 <group expand="0" string="Group By...">
                     <filter
                         name="group_by_category"


### PR DESCRIPTION
Often I need to search by specific title only, but I get a lot of unwanted results because Odoo will search among the content.

@ForgeFlow

