### PR TITLE
[14.0][FIX] document_url: Improve the definition of mimetype=application/link only to records linked to a model to avoid errors.

### DIFF
--- a/document_url/__manifest__.py
+++ b/document_url/__manifest__.py
@@ -2,7 +2,7 @@
 # Copyright 2020 Tecnativa - Manuel Calero
 {
     "name": "URL attachment",
-    "version": "14.0.1.0.0",
+    "version": "14.0.1.1.0",
     "category": "Tools",
     "author": "Tecnativa, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/knowledge",

--- a/document_url/migrations/14.0.1.1.0/post-migration.py
+++ b/document_url/migrations/14.0.1.1.0/post-migration.py
@@ -1,0 +1,24 @@
+# Copyright 2021 Tecnativa - Víctor Martínez
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.logged_query(
+        env.cr,
+        """
+        UPDATE ir_attachment
+        SET mimetype = 'text/css'
+        WHERE mimetype = 'application/link' AND res_id = 0 AND name LIKE '%.%css'
+        """,
+    )
+    openupgrade.logged_query(
+        env.cr,
+        """
+        UPDATE ir_attachment
+        SET mimetype = 'application/javascript'
+        WHERE mimetype = 'application/link' AND res_id = 0 AND name LIKE '%.js'
+        """,
+    )

--- a/document_url/models/ir_attachment.py
+++ b/document_url/models/ir_attachment.py
@@ -8,6 +8,6 @@ class IrAttachment(models.Model):
     _inherit = "ir.attachment"
 
     def _compute_mimetype(self, values):
-        if values.get("url"):
+        if values.get("url") and values.get("res_model") and values.get("res_id"):
             return "application/link"
         return super()._compute_mimetype(values)

--- a/document_url/view/document_url_view.xml
+++ b/document_url/view/document_url_view.xml
@@ -10,6 +10,7 @@
             <link
                 href="/document_url/static/src/scss/document_url.scss"
                 rel="stylesheet"
+                type="text/scss"
             />
         </xpath>
     </template>


### PR DESCRIPTION
Improve the definition of mimetype=application/link only to records linked to a model to avoid errors with the developer model (with assets).

Related to: https://github.com/OCA/knowledge/issues/322

Please @Tardo and @pedrobaeza can you review it?

@Tecnativa