### PR TITLE
[12.0]IMP: Add single menu for content browsing

### DIFF
--- a/document_page/__manifest__.py
+++ b/document_page/__manifest__.py
@@ -3,36 +3,31 @@
 
 
 {
-    'name': 'Document Page',
-    'version': '12.0.1.3.0',
-    'category': 'Knowledge Management',
-    'author': 'OpenERP SA, Odoo Community Association (OCA)',
-    'images': [
-        'images/category_list.png',
-        'images/create_category.png',
-        'images/page_list.png',
-        'images/create_page.png',
-        'images/customer_invoice.jpeg',
-        'images/page_history.png',
+    "name": "Documentation Page",
+    "version": "12.0.1.4.0",
+    "category": "Knowledge Management",
+    "author": "OpenERP SA, Odoo Community Association (OCA)",
+    "images": [
+        "images/category_list.png",
+        "images/create_category.png",
+        "images/page_list.png",
+        "images/create_page.png",
+        "images/customer_invoice.jpeg",
+        "images/page_history.png",
     ],
-    'website': 'https://github.com/OCA/knowledge',
-    'license': 'AGPL-3',
-    'depends': [
-        'mail',
-        'knowledge',
+    "website": "https://github.com/OCA/knowledge",
+    "license": "AGPL-3",
+    "depends": ["mail", "knowledge"],
+    "data": [
+        "security/document_page_security.xml",
+        "security/ir.model.access.csv",
+        "wizard/document_page_create_menu.xml",
+        "wizard/document_page_show_diff.xml",
+        "views/document_page.xml",
+        "views/document_page_category.xml",
+        "views/document_page_history.xml",
+        "views/document_page_assets.xml",
+        "views/report_document_page.xml",
     ],
-    'data': [
-        'security/document_page_security.xml',
-        'security/ir.model.access.csv',
-        'wizard/document_page_create_menu.xml',
-        'wizard/document_page_show_diff.xml',
-        'views/document_page.xml',
-        'views/document_page_category.xml',
-        'views/document_page_history.xml',
-        'views/document_page_assets.xml',
-        'views/report_document_page.xml',
-    ],
-    'demo': [
-        'demo/document_page.xml'
-    ],
+    "demo": ["demo/document_page.xml"],
 }

--- a/document_page/models/document_page.py
+++ b/document_page/models/document_page.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2004-2010 Tiny SPRL (<http://tiny.be>).
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import api, fields, models, _
+from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
 
 
@@ -9,49 +9,46 @@ class DocumentPage(models.Model):
     """This class is use to manage Document."""
 
     _name = "document.page"
-    _inherit = ['mail.thread', 'mail.activity.mixin']
+    _inherit = ["mail.thread", "mail.activity.mixin"]
     _description = "Document Page"
-    _order = 'name'
+    _parent_name = "parent_id"
+    _parent_store = True
+    _rec_name = "complete_name"
+    _order = "type, sequence, complete_name"
 
-    name = fields.Char('Title', required=True)
+    name = fields.Char("Title", required=True)
     type = fields.Selection(
-        [('content', 'Content'), ('category', 'Category')],
-        'Type',
+        [("content", "Content"), ("category", "Category")],
+        "Type",
         help="Page type",
-        default="content"
+        default="content",
     )
     active = fields.Boolean(default=True)
     parent_id = fields.Many2one(
-        'document.page',
-        'Category',
-        domain=[('type', '=', 'category')]
+        "document.page", "Category", domain=[("type", "=", "category")]
     )
-    child_ids = fields.One2many(
-        'document.page',
-        'parent_id',
-        'Children'
-    )
+    child_ids = fields.One2many("document.page", "parent_id", "Children")
     content = fields.Text(
         "Content",
-        compute='_compute_content',
-        inverse='_inverse_content',
-        search='_search_content',
+        compute="_compute_content",
+        inverse="_inverse_content",
+        search="_search_content",
         required=True,
         copy=True,
     )
 
     # no-op computed field
     draft_name = fields.Char(
-        string='Name',
-        help='Name for the changes made',
+        string="Name",
+        help="Name for the changes made",
         compute=lambda x: x,
         inverse=lambda x: x,
     )
 
     # no-op computed field
     draft_summary = fields.Char(
-        string='Summary',
-        help='Describe the changes made',
+        string="Summary",
+        help="Describe the changes made",
         compute=lambda x: x,
         inverse=lambda x: x,
     )
@@ -59,58 +56,88 @@ class DocumentPage(models.Model):
     template = fields.Html(
         "Template",
         help="Template that will be used as a content template "
-             "for all new page of this category.",
+        "for all new page of this category.",
     )
     history_head = fields.Many2one(
-        'document.page.history',
-        'HEAD',
-        compute='_compute_history_head',
+        "document.page.history",
+        "HEAD",
+        compute="_compute_history_head",
         store=True,
         auto_join=True,
     )
     history_ids = fields.One2many(
-        'document.page.history',
-        'page_id',
-        'History',
-        order='create_date DESC',
+        "document.page.history",
+        "page_id",
+        "History",
+        order="create_date DESC",
         readonly=True,
     )
-    menu_id = fields.Many2one(
-        'ir.ui.menu',
-        "Menu",
-        readonly=True,
-    )
+    menu_id = fields.Many2one("ir.ui.menu", "Menu", readonly=True,)
     content_date = fields.Datetime(
-        'Last Contribution Date',
-        related='history_head.create_date',
+        "Last Contribution Date",
+        related="history_head.create_date",
         store=True,
         index=True,
         readonly=True,
     )
     content_uid = fields.Many2one(
-        'res.users',
-        'Last Contributor',
-        related='history_head.create_uid',
+        "res.users",
+        "Last Contributor",
+        related="history_head.create_uid",
         store=True,
         index=True,
         readonly=True,
     )
     company_id = fields.Many2one(
-        'res.company',
-        'Company',
-        help='If set, page is accessible only from this company',
+        "res.company",
+        "Company",
+        help="If set, page is accessible only from this company",
         index=True,
-        ondelete='cascade',
+        ondelete="cascade",
     )
     backend_url = fields.Char(
-        string='Backend URL',
-        help='Use it to link resources univocally',
-        compute='_compute_backend_url',
+        string="Backend URL",
+        help="Use it to link resources univocally",
+        compute="_compute_backend_url",
     )
 
-    @api.depends('menu_id', 'parent_id.menu_id')
+    sequence = fields.Integer(
+        string="Sequence", default=10, help="Used to organise the category."
+    )
+
+    parent_path = fields.Char(index=True)
+    complete_name = fields.Char(
+        "Complete Name", compute="_compute_complete_name", store=True
+    )
+
+    image = fields.Binary("Image", attachment=True,)
+
+    color = fields.Integer(string="Color Index")
+
+    @api.multi
+    def write(self, vals):
+        child_ids = self
+        if vals.get("color", False) and len(vals) == 1:
+            child_ids = self.search(
+                [("type", "=", "category"),
+                 ("parent_id", "child_of", self.ids)]
+            )
+        res = super(DocumentPage, child_ids).write(vals)
+        return res
+
+    @api.depends("name", "parent_id.complete_name")
+    def _compute_complete_name(self):
+        for category in self:
+            if category.parent_id:
+                category.complete_name = "{} / {}".format(
+                    category.parent_id.complete_name, category.name,
+                )
+            else:
+                category.complete_name = category.name
+
+    @api.depends("menu_id", "parent_id.menu_id")
     def _compute_backend_url(self):
-        tmpl = '/web#id={}&model=document.page&view_type=form'
+        tmpl = "/web#id={}&model=document.page&view_type=form"
         for rec in self:
             url = tmpl.format(rec.id)
             # retrieve action
@@ -120,13 +147,13 @@ class DocumentPage(models.Model):
                 action = parent.menu_id.action
                 parent = parent.parent_id
             if action:
-                url += '&action={}'.format(action.id)
+                url += "&action={}".format(action.id)
             rec.backend_url = url
 
-    @api.constrains('parent_id')
+    @api.constrains("parent_id")
     def _check_parent_id(self):
         if not self._check_recursion():
-            raise ValidationError(_('You cannot create recursive categories.'))
+            raise ValidationError(_("You cannot create recursive categories."))
 
     @api.multi
     def _get_page_index(self, link=True):
@@ -135,7 +162,7 @@ class DocumentPage(models.Model):
         index = []
         for subpage in self.child_ids:
             index += ["<li>" + subpage._get_page_index() + "</li>"]
-        r = ''
+        r = ""
         if link:
             r = '<a href="{}">{}</a>'.format(self.backend_url, self.name)
         if index:
@@ -143,35 +170,37 @@ class DocumentPage(models.Model):
         return r
 
     @api.multi
-    @api.depends('history_head')
+    @api.depends("history_head")
     def _compute_content(self):
         for rec in self:
-            if rec.type == 'category':
+            if rec.type == "category":
                 rec.content = rec._get_page_index(link=False)
             else:
                 if rec.history_head:
                     rec.content = rec.history_head.content
                 else:
                     # html widget's default, so it doesn't trigger ghost save
-                    rec.content = '<p><br></p>'
+                    rec.content = "<p><br></p>"
 
     @api.multi
     def _inverse_content(self):
         for rec in self:
-            if rec.type == 'content' and \
-                    rec.content != rec.history_head.content:
-                rec._create_history({
-                    'name': rec.draft_name,
-                    'summary': rec.draft_summary,
-                    'content': rec.content,
-                })
+            if rec.type == "content" \
+                    and rec.content != rec.history_head.content:
+                rec._create_history(
+                    {
+                        "name": rec.draft_name,
+                        "summary": rec.draft_summary,
+                        "content": rec.content,
+                    }
+                )
 
     @api.multi
     def _search_content(self, operator, value):
-        return [('history_head.content', operator, value)]
+        return [("history_head.content", operator, value)]
 
     @api.multi
-    @api.depends('history_ids')
+    @api.depends("history_ids")
     def _compute_history_head(self):
         for rec in self:
             if rec.history_ids:
@@ -180,20 +209,20 @@ class DocumentPage(models.Model):
     @api.multi
     def _create_history(self, vals):
         self.ensure_one()
-        history = self.env['document.page.history']
-        vals['page_id'] = self.id
+        history = self.env["document.page.history"]
+        vals["page_id"] = self.id
         return history.create(vals)
 
     @api.onchange("parent_id")
     def _onchange_parent_id(self):
         """We Set it the right content to the new parent."""
-        if not self.content or self.content == '<p><br></p>':
+        if not self.content or self.content == "<p><br></p>":
             if self.parent_id and self.parent_id.type == "category":
-                    self.content = self.parent_id.template
+                self.content = self.parent_id.template
 
     @api.multi
     def unlink(self):
-        menus = self.mapped('menu_id')
+        menus = self.mapped("menu_id")
         res = super().unlink()
         menus.unlink()
         return res

--- a/document_page/readme/CONTRIBUTORS.rst
+++ b/document_page/readme/CONTRIBUTORS.rst
@@ -8,3 +8,5 @@
 * `Tecnativa <https://www.tecnativa.com>`_:
 
   * Víctor Martínez
+
+* Florent THOMAS <florent.thomas@mind-and-go.com>

--- a/document_page/static/src/js/document_page_kanban.js
+++ b/document_page/static/src/js/document_page_kanban.js
@@ -1,0 +1,28 @@
+odoo.define("document_page.update_kanban", function(require) {
+    "use strict";
+    
+    var KanbanRecord = require("web.KanbanRecord");
+
+    KanbanRecord.include({
+        // --------------------------------------------------------------------------
+        // Private
+        // --------------------------------------------------------------------------
+
+        /**
+         * @override
+         * @private
+         */
+        _openRecord: function() {
+            if (
+                this.modelName === "document.page" &&
+                this.$(".o_document_page_kanban_boxes a").length
+            ) {
+                this.$(".o_document_page_kanban_boxes a")
+                    .first()
+                    .click();
+            } else {
+                this._super.apply(this, arguments);
+            }
+        }
+    });
+});

--- a/document_page/views/document_menus.xml
+++ b/document_page/views/document_menus.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<odoo>
+	<menuitem id="menu_main_wiki"
+              name="Wiki"
+              action="action_category_navigation"
+              parent="knowledge.menu_document_root"
+              sequence="1"/>
+
+    <menuitem id="menu_wiki"
+              name="Pages"
+              parent="knowledge.menu_document_root"
+              sequence="10"/>
+
+    <menuitem id="menu_page"
+              name="Pages"
+              parent="menu_wiki"
+              action="action_page"
+              sequence="20"/>
+
+	<menuitem id="menu_category" 
+			  parent="menu_wiki"
+			  name="Categories" 
+			  action="action_category" 
+			  sequence="20" />
+
+</odoo>

--- a/document_page/views/document_page.xml
+++ b/document_page/views/document_page.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" ?>
 <odoo>
 
     <!-- wiki tree view -->
@@ -9,9 +9,9 @@
         <field name="priority">100</field>
         <field name="arch" type="xml">
             <tree string="Document Page">
-                <field name="name"/>
-                <field name="content_uid"/>
-                <field name="content_date"/>
+                <field name="name" />
+                <field name="content_uid" />
+                <field name="content_date" />
             </tree>
         </field>
     </record>
@@ -22,12 +22,12 @@
         <field name="model">document.page</field>
         <field name="arch" type="xml">
             <tree string="Document Page">
-                <field name="name"/>
-                <field name="parent_id"/>
-                <field name="company_id" groups="base.group_multi_company"/>
-                <field name="create_uid" invisible="1"/>
-                <field name="content_uid"/>
-                <field name="content_date"/>
+                <field name="name" />
+                <field name="parent_id" />
+                <field name="company_id" groups="base.group_multi_company" />
+                <field name="create_uid" invisible="1" />
+                <field name="content_uid" />
+                <field name="content_date" />
             </tree>
         </field>
     </record>
@@ -41,27 +41,27 @@
                 <sheet>
                     <div class="oe_button_box" name="button_box">
                         <button name="toggle_active" type="object" groups="document_page.group_document_manager" class="oe_stat_button" icon="fa-archive">
-                            <field name="active" widget="boolean_button" options="{'terminology': 'archive'}"/>
+                            <field name="active" widget="boolean_button" options="{'terminology': 'archive'}" />
                         </button>
                     </div>
-                    <field name="type" invisible="1"/>
+                    <field name="type" invisible="1" />
                     <h1>
-                        <field name="name" placeholder="Name"/>
+                        <field name="name" placeholder="Name" />
                     </h1>
                     <group>
                         <div>
-                            <field name="content" widget="html" placeholder="e.g. Once upon a time..." required="1" options="{'safe': True}"/>
+                            <field name="content" widget="html" placeholder="e.g. Once upon a time..." required="1" options="{'safe': True}" />
                         </div>
                     </group>
                     <notebook>
                         <page name="info" string="Information">
                             <group>
                                 <group>
-                                    <field name="parent_id" string="Category" required="True" context="{'default_type':'category'}"/>
-                                    <field name="company_id" groups="base.group_multi_company"/>
-                                    <field name="content_uid"/>
-                                    <field name="content_date"/>
-                                    <field name="menu_id" readonly="1" attrs="{'invisible': [('menu_id','=',False)]}"/>
+                                    <field name="parent_id" string="Category" required="True" context="{'default_type':'category'}" />
+                                    <field name="company_id" groups="base.group_multi_company" />
+                                    <field name="content_uid" />
+                                    <field name="content_date" />
+                                    <field name="menu_id" readonly="1" attrs="{'invisible': [('menu_id','=',False)]}" />
                                 </group>
                                 <group string="Revision" class="oe_edit_only">
                                     <field name="draft_name" placeholder="Rev 01" required="True" class="oe_edit_only" />
@@ -72,20 +72,20 @@
                         <page name="history" string="History">
                             <field name="history_ids">
                                 <tree>
-                                    <field name="id"/>
-                                    <field name="create_date"/>
-                                    <field name="name"/>
-                                    <field name="summary"/>
-                                    <field name="create_uid"/>
+                                    <field name="id" />
+                                    <field name="create_date" />
+                                    <field name="name" />
+                                    <field name="summary" />
+                                    <field name="create_uid" />
                                 </tree>
                             </field>
                         </page>
                     </notebook>
                 </sheet>
                 <div class="oe_chatter">
-                    <field name="message_follower_ids" widget="mail_followers"/>
-                    <field name="activity_ids" widget="mail_activity"/>
-                    <field name="message_ids" widget="mail_thread"/>
+                    <field name="message_follower_ids" widget="mail_followers" />
+                    <field name="activity_ids" widget="mail_activity" />
+                    <field name="message_ids" widget="mail_thread" />
                 </div>
             </form>
         </field>
@@ -96,11 +96,11 @@
         <field name="model">document.page</field>
         <field name="arch" type="xml">
             <form string="Document Page" create="0">
-                <field name="type" invisible="1"/>
+                <field name="type" invisible="1" />
                 <h1>
-                    <field name="name" placeholder="Name"/>
+                    <field name="name" placeholder="Name" />
                 </h1>
-                <field name="content" widget="html" class="oe_view_only" required="1" options='{"safe": True}'/>
+                <field name="content" widget="html" class="oe_view_only" required="1" options='{"safe": True}' />
             </form>
         </field>
     </record>
@@ -111,15 +111,14 @@
         <field name="model">document.page</field>
         <field name="arch" type="xml">
             <search string="Document Page">
-                <field name="name" string="Content"
-                       filter_domain="['|', ('name','ilike',self), ('content','ilike',self)]"/>
-                <field name="parent_id"/>
-                <field name="create_uid"/>
-                <field name="content_uid"/>
+                <field name="name" string="Content" filter_domain="['|', ('name','ilike',self), ('content','ilike',self)]" />
+                <field name="parent_id" />
+                <field name="create_uid" />
+                <field name="content_uid" />
                 <group expand="0" string="Group By...">
-                    <filter name="group_by_category" string="Category" context="{'group_by':'parent_id'}"/>
-                    <filter name="group_by_author" string="Author" context="{'group_by':'create_uid'}"/>
-                    <filter name="group_by_last_contributor" string="Last Contributor" context="{'group_by':'content_uid'}"/>
+                    <filter name="group_by_category" string="Category" context="{'group_by':'parent_id'}" />
+                    <filter name="group_by_author" string="Author" context="{'group_by':'create_uid'}" />
+                    <filter name="group_by_last_contributor" string="Last Contributor" context="{'group_by':'content_uid'}" />
                 </group>
             </search>
         </field>
@@ -134,8 +133,8 @@
         <field name="context">{'default_type': 'content'}</field>
         <field name="view_type">form</field>
         <field name="view_mode">tree,form</field>
-        <field name="view_id" ref="view_wiki_tree"/>
-        <field name="search_view_id" ref="view_wiki_filter"/>
+        <field name="view_id" ref="view_wiki_tree" />
+        <field name="search_view_id" ref="view_wiki_filter" />
         <field name="help" type="html">
             <p class="oe_view_nocontent_create">
                 Click to create a new web page.
@@ -144,40 +143,26 @@
     </record>
 
     <record id="action_page_view_tree" model="ir.actions.act_window.view">
-        <field name="sequence" eval="0"/>
+        <field name="sequence" eval="0" />
         <field name="view_mode">tree</field>
-        <field name="view_id" ref="view_wiki_tree"/>
-        <field name="act_window_id" ref="action_page"/>
+        <field name="view_id" ref="view_wiki_tree" />
+        <field name="act_window_id" ref="action_page" />
     </record>
 
     <record id="action_page_view_form" model="ir.actions.act_window.view">
-        <field name="sequence" eval="5"/>
+        <field name="sequence" eval="5" />
         <field name="view_mode">form</field>
-        <field name="view_id" ref="view_wiki_form"/>
-        <field name="act_window_id" ref="action_page"/>
+        <field name="view_id" ref="view_wiki_form" />
+        <field name="act_window_id" ref="action_page" />
     </record>
 
 
-    <menuitem id="menu_wiki"
-              name="Pages"
-              parent="knowledge.menu_document_root"
-              sequence="10"/>
+    <menuitem id="menu_wiki" name="Pages" parent="knowledge.menu_document_root" sequence="10" />
 
 
-    <menuitem id="menu_page"
-              name="Pages"
-              parent="menu_wiki"
-              action="action_page"
-              sequence="20"/>
+    <menuitem id="menu_page" name="Pages" parent="menu_wiki" action="action_page" sequence="20" />
 
 
-    <act_window
-            id="action_related_page_create_menu"
-            name="Create Menu"
-            res_model="document.page.create.menu"
-            target="new"
-            view_type="form"
-            view_mode="form"
-            src_model="document.page"/>
+    <act_window id="action_related_page_create_menu" name="Create Menu" res_model="document.page.create.menu" target="new" view_type="form" view_mode="form" src_model="document.page" />
 
 </odoo>

--- a/document_page/views/document_page_assets.xml
+++ b/document_page/views/document_page_assets.xml
@@ -1,9 +1,20 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <odoo>
 
-    <template id="assets_backend" name="document_page assets" inherit_id="web.assets_backend">
+    <template
+        id="assets_backend"
+        name="document_page assets"
+        inherit_id="web.assets_backend"
+    >
         <xpath expr="." position="inside">
-            <link rel="stylesheet" href="/document_page/static/src/css/document_page.css"/>
+            <link
+                rel="stylesheet"
+                href="/document_page/static/src/css/document_page.css"
+            />
+            <script
+                type="text/javascript"
+                src="/document_page/static/src/js/document_page_kanban.js"
+            />
         </xpath>
     </template>
 

--- a/document_page/views/document_page_category.xml
+++ b/document_page/views/document_page_category.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" ?>
 <odoo>
 
     <!-- Category Views -->
@@ -8,16 +8,21 @@
         <field name="arch" type="xml">
             <form string="Category">
                 <sheet>
-                    <field name="type" invisible="1"/>
-                    <h1><field name="name" placeholder="Name"/></h1>
+                    <field name="type" invisible="1" />
+                    <field name="image" widget="image" class="oe_avatar" />
+                    <div class="oe_title">
+                        <h1>
+                            <field name="name" placeholder="Name" />
+                        </h1>
+                    </div>
                     <group>
                         <group>
-                            <field name="parent_id" string="Category" context="{'default_type':'category'}"/>
+                            <field name="parent_id" string="Category" context="{'default_type':'category'}" />
                         </group>
                         <group>
-                            <field name="write_uid" groups="base.group_no_one"/>
-                            <field name="write_date" groups="base.group_no_one"/>
-                            <field name="menu_id" groups="base.group_no_one"/>
+                            <field name="write_uid" groups="base.group_no_one" />
+                            <field name="write_date" groups="base.group_no_one" />
+                            <field name="menu_id" groups="base.group_no_one" />
                         </group>
                     </group>
                     <notebook>
@@ -25,29 +30,147 @@
                             <field name="template" placeholder="e.g. Once upon a time..." />
                         </page>
                         <page string="Documents" name="documents">
-                            <field name="content" widget="html" class="oe_view_only" options='{"safe": True}' />
+                            <field name="content" widget="html" class="oe_view_only" options="{'safe': True}" />
                         </page>
                     </notebook>
                 </sheet>
                 <div class="oe_chatter">
-                    <field name="message_follower_ids" widget="mail_followers"/>
-                    <field name="activity_ids" widget="mail_activity"/>
-                    <field name="message_ids" widget="mail_thread"/>
+                    <field name="message_follower_ids" widget="mail_followers" />
+                    <field name="activity_ids" widget="mail_activity" />
+                    <field name="message_ids" widget="mail_thread" />
                 </div>
             </form>
         </field>
     </record>
+
+
+    <record id="view_browse_top_document_filter" model="ir.ui.view">
+        <field name="name">document.page.category.search</field>
+        <field name="model">document.page</field>
+        <field name="inherit_id" ref="view_wiki_filter" />
+        <field name="arch" type="xml">
+            <field name="content_uid" position="after">
+                <separator />
+                <filter string="Top Level Ressources" name="no_parent_id" domain="[('parent_id', '=', False)]" />
+            </field>
+        </field>
+    </record>
+
+    <record id="action_browse_top_content" model="ir.actions.act_window">
+        <field name="name">Browse Wiki Content</field>
+        <field name="res_model">document.page</field>
+        <field name="domain">[]</field>
+        <field name="context">{'default_type': 'content', 'search_default_no_parent_id':1, }</field>
+        <field name="view_type">form</field>
+        <field name="view_mode">kanban,tree,form</field>
+        <field name="search_view_id" ref="view_browse_top_document_filter" />
+    </record>
+
+    <record id="action_browse_all_content" model="ir.actions.act_window">
+        <field name="name">Browse Wiki Content</field>
+        <field name="res_model">document.page</field>
+        <field name="domain">[]</field>
+        <field name="context">{'default_type': 'content', 'search_default_parent_id': [active_id] }</field>
+        <field name="view_type">form</field>
+        <field name="view_mode">kanban,tree,form</field>
+        <field name="search_view_id" ref="view_wiki_filter" />
+    </record>
+
+    <record id="view_browse_content_kanban" model="ir.ui.view">
+        <field name="name">document.page.browse.kanban</field>
+        <field name="model">document.page</field>
+        <field name="arch" type="xml">
+            <kanban>
+                <field name="id" />
+                <field name="name" />
+                <field name="display_name" />
+                <field name="create_uid" />
+                <field name="write_date" />
+                <field name="parent_id" />
+                <field name="content_uid" />
+                <field name="image" />
+                <field name="type" />
+                <field name="color" />
+                <templates>
+                    <t t-name="kanban-box">
+                        <div t-att-class="'oe_kanban_global_area'  + ' oe_kanban_color_'+ (kanban_getcolor(record.color.raw_value)) + ' oe_kanban_global_click' ">
+                            <div class="o_kanban_image">
+                                <div class="o_kanban_image_wrapper">
+                                    <t t-if="record.type.raw_value == 'category'">
+                                        <img class="o_kanban_image" t-if="record.image.raw_value" t-att-src="kanban_image('document.page', 'image', record.id.raw_value)" t-att-alt="record.display_name" />
+                                        <span style="font-size: 64px; color: lightslategray">
+                                            <i t-if="!record.image.raw_value" class="o_kanban_image fa fa-folder-open" />
+                                        </span>
+                                    </t>
+                                    <t t-if="record.type.raw_value == 'content'">
+                                        <span style="font-size: 64px; color: lightgray">
+                                            <i class="o_kanban_image fa fa-file" />
+                                        </span>
+                                    </t>
+                                </div>
+                            </div>
+                            <div class="o_kanban_details">
+                                <div class="o_kanban_details_wrapper">
+                                    <div class="o_kanban_record_top">
+                                        <div class="o_kanban_record_title o_text_overflow">
+                                            <strong>
+                                                <field name="name" />
+                                            </strong>
+                                            <br />
+                                            <small t-if="record.parent_id.raw_value">
+                                                <img t-att-src="kanban_image('document.page', 'image', record.parent_id.raw_value)" t-att-alt="record.parent_id.display_name" width="24" height="24" />
+                                                <field name="parent_id" />
+                                            </small>
+                                        </div>
+                                    </div>
+                                    <div class="o_dropdown_kanban dropdown" groups="base.group_user">
+                                        <a role="button" class="dropdown-toggle o-no-caret btn" data-toggle="dropdown" data-display="static" href="#" aria-label="Dropdown menu" title="Dropdown menu">
+                                            <span class="fa fa-ellipsis-v" />
+                                        </a>
+                                        <div class="dropdown-menu" role="menu">
+                                            <ul class="oe_kanban_colorpicker" data-field="color" />
+                                        </div>
+                                    </div>
+                                    <div class="o_kanban_record_body">
+                                        <div class="o_kanban_tags_section">
+                                        </div>
+                                    </div>
+                                    <div class="o_kanban_record_bottom" t-if="record.type.raw_value == 'content'">
+                                        <div class="oe_kanban_bottom_left">
+                                            <field name="write_date" widget="date" />
+                                        </div>
+                                        <div class="oe_kanban_bottom_right">
+                                            <img t-att-src="kanban_image('res.users', 'image_small', record.content_uid.raw_value)" t-att-title="record.content_uid.value" t-att-alt="record.content_uid.value" width="24" height="24" class="oe_kanban_avatar" />
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div t-if="record.type.raw_value == 'category'" class="o_document_page_kanban_boxes">
+                                <a class="o_document_page_kanban_box" name="%(action_browse_all_content)d" type="action">
+                                </a>
+                            </div>
+                        </div>
+                    </t>
+                </templates>
+            </kanban>
+        </field>
+    </record>
+
 
     <record id="view_category_tree" model="ir.ui.view">
         <field name="name">document.page.category.tree</field>
         <field name="model">document.page</field>
         <field name="arch" type="xml">
             <tree string="Categories">
-                <field name="name"/>
-                <field name="parent_id"/>
-                <field name="create_uid" invisible="1"/>
-                <field name="write_uid"/>
-                <field name="write_date"/>
+                <field name="sequence" widget="handle" />
+                <field name="name" />
+
+
+                <field name="parent_id" />
+                <field name="create_uid" invisible="1" />
+                <field name="write_uid" />
+                <field name="write_date" />
             </tree>
         </field>
     </record>
@@ -57,19 +180,20 @@
         <field name="model">document.page</field>
         <field name="arch" type="xml">
             <search string="Document Category">
-                <field name="name" string="Content"
-                       filter_domain="['|', ('name','ilike',self), ('template','ilike',self)]"/>
-                <field name="parent_id"/>
-                <field name="create_uid"/>
-                <field name="content_uid"/>
+                <field name="name" string="Content" filter_domain="['|', ('name','ilike',self), ('template','ilike',self)]" />
+                <field name="parent_id" />
+                <field name="create_uid" />
+                <field name="content_uid" />
                 <group expand="0" string="Group By...">
-                    <filter name="group_by_category" string="Category" context="{'group_by':'parent_id'}"/>
-                    <filter name="group_by_author" string="Author" context="{'group_by':'create_uid'}"/>
-                    <filter name="group_by_last_contributor" string="Last Contributor" context="{'group_by':'content_uid'}"/>
+                    <filter name="group_by_category" string="Category" context="{'group_by':'parent_id'}" />
+                    <filter name="group_by_author" string="Author" context="{'group_by':'create_uid'}" />
+                    <filter name="group_by_last_contributor" string="Last Contributor" context="{'group_by':'content_uid'}" />
                 </group>
             </search>
         </field>
     </record>
+
+
 
     <!-- Category Action -->
     <record id="action_category" model="ir.actions.act_window">
@@ -79,29 +203,26 @@
         <field name="context">{'default_type': 'category'}</field>
         <field name="view_type">form</field>
         <field name="view_mode">tree,form</field>
-        <field name="view_id" ref="view_category_tree"/>
-        <field name="search_view_id" ref="view_document_category_filter"/>
+        <field name="view_id" ref="view_category_tree" />
+        <field name="search_view_id" ref="view_document_category_filter" />
     </record>
 
     <record id="action_category_view_tree" model="ir.actions.act_window.view">
         <field name="sequence" eval="0" />
         <field name="view_mode">tree</field>
-        <field name="view_id" ref="view_category_tree"/>
-        <field name="act_window_id" ref="action_category"/>
+        <field name="view_id" ref="view_category_tree" />
+        <field name="act_window_id" ref="action_category" />
     </record>
 
     <record id="action_category_view_form" model="ir.actions.act_window.view">
         <field name="sequence" eval="5" />
         <field name="view_mode">form</field>
-        <field name="view_id" ref="view_category_form"/>
-        <field name="act_window_id" ref="action_category"/>
+        <field name="view_id" ref="view_category_form" />
+        <field name="act_window_id" ref="action_category" />
     </record>
 
-    <menuitem id="menu_category"
-              parent="menu_wiki"
-              name="Categories"
-              action="action_category"
-              sequence="20"/>
+    <menuitem id="menu_category" parent="menu_wiki" name="Categories" action="action_category" sequence="20" />
 
+    <menuitem id="menu_browse_content" parent="knowledge.menu_document_root" name="Browse Wiki Content" action="action_browse_top_content" sequence="5" />
 
 </odoo>


### PR DESCRIPTION
* Categories and content are now available and browsable in a single menu.
* Navigation helps user to find content easily
* Cleanups for pylint and flake

superseeds https://github.com/OCA/knowledge/pull/318