### PR TITLE
[15.0][FIX] knowledge: The internal user group is added as an inheritance to the new group

### DIFF
--- a/knowledge/security/knowledge_security.xml
+++ b/knowledge/security/knowledge_security.xml
@@ -3,6 +3,7 @@
     <record id="group_document_user" model="res.groups">
         <field name="name">Knowledge user</field>
         <field name="category_id" ref="module_category_knowledge" />
+        <field name="implied_ids" eval="[(4, ref('base.group_user'))]" />
         <field name="users" eval="[(4, ref('base.user_root'))]" />
     </record>
     <record id="group_ir_attachment_user" model="res.groups">


### PR DESCRIPTION
FWP from 14.0: https://github.com/OCA/knowledge/pull/327

The internal user group is added as an inheritance to the new group.

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa