### PR TITLE
[14.0][FIX] document_page_tag: change 'Tags must me unique' to 'Tags must be unique'

### DIFF
--- a/document_page_tag/models/document_page_tag.py
+++ b/document_page_tag/models/document_page_tag.py
@@ -12,7 +12,7 @@ class DocumentPageTag(models.Model):
     active = fields.Boolean(default=True)
 
     _sql_constraints = [
-        ("unique_name", "unique(name)", "Tags must me unique"),
+        ("unique_name", "unique(name)", "Tags must be unique"),
     ]
 
     @api.model


### PR DESCRIPTION
Fix a spelling error in the document_page_tag by changing 'Tags must me unique' to 'Tags must be unique'