### PR TITLE
[14.0][IMP] document_page_tag: add side search panel with tags.

### DIFF
--- a/document_page_tag/views/document_page.xml
+++ b/document_page_tag/views/document_page.xml
@@ -21,6 +21,15 @@
             <field name="name" position="after">
                 <field name="tag_ids" widget="many2one" />
             </field>
+            <xpath expr="//searchpanel" position="inside">
+                <field
+                    name="tag_ids"
+                    select="multi"
+                    icon="fa-folder"
+                    string="Tags"
+                    enable_counters="1"
+                />
+            </xpath>
         </field>
     </record>
 


### PR DESCRIPTION
A search side panel with tags is added as shown in the following screenshot.

![Searchpanel_Tags](https://user-images.githubusercontent.com/101106685/166685749-22534e63-d55f-4d16-b64d-185a985c9909.png)
