### PR TITLE
[15.0][IMP] document_page_tag: add side search panel with tags.

### DIFF
--- a/document_page_tag/views/document_page.xml
+++ b/document_page_tag/views/document_page.xml
@@ -21,6 +21,15 @@
             <field name="name" position="after">
                 <field name="tag_ids" widget="many2one" />
             </field>
+            <xpath expr="//searchpanel" position="inside">
+                <field
+                    name="tag_ids"
+                    select="multi"
+                    icon="fa-folder"
+                    string="Tags"
+                    enable_counters="1"
+                />
+            </xpath>
         </field>
     </record>
 


### PR DESCRIPTION
A search side panel with tags is added as shown in the following screenshot. Like PR v14.0 #343

![Searchpanel_tags_v15](https://user-images.githubusercontent.com/101106685/166688824-3c06bbc8-6e84-426c-a67a-e6e211121fd6.png)
