### PR TITLE
[14.0][FIX]: change the priority views form.

### DIFF
--- a/document_page/views/document_page.xml
+++ b/document_page/views/document_page.xml
@@ -33,6 +33,7 @@
     <record id="view_wiki_form" model="ir.ui.view">
         <field name="name">document.page.form</field>
         <field name="model">document.page</field>
+        <field name="priority">10</field>
         <field name="arch" type="xml">
             <form string="Document Page">
                 <sheet>

--- a/document_page/views/document_page_category.xml
+++ b/document_page/views/document_page_category.xml
@@ -4,6 +4,7 @@
     <record id="view_category_form" model="ir.ui.view">
         <field name="name">document.page.category.form</field>
         <field name="model">document.page</field>
+        <field name="priority">16</field>
         <field name="arch" type="xml">
             <form string="Category">
                 <sheet>


### PR DESCRIPTION
When we plan an activity in a page and from the kanban view of planned activities we click on an activity it loads the document.page.category.form view instead of document.page.form view. 
The issue is solved by changing the priorities of both views.