### PR TITLE
[15.0][IMP] document_page: copy document function.

### DIFF
--- a/document_page/models/document_page.py
+++ b/document_page/models/document_page.py
@@ -180,3 +180,13 @@ class DocumentPage(models.Model):
         res = super().unlink()
         menus.unlink()
         return res
+
+    def copy(self, default=None):
+        default = dict(
+            default or {},
+            name=_("%s (copy)") % self.name,
+            content=self.content,
+            draft_name="1.0",
+            draft_summary=_("summary"),
+        )
+        return super(DocumentPage, self).copy(default=default)

--- a/document_page/tests/test_document_page.py
+++ b/document_page/tests/test_document_page.py
@@ -49,3 +49,11 @@ class TestDocumentPage(common.TransactionCase):
                 page.id, menu.action.id
             ),
         )
+
+    def test_page_copy(self):
+        page = self.page_obj.create({"name": "Test Page 3", "content": "Test content"})
+        page_copy = page.copy()
+        self.assertEqual(page_copy.name, page.name + " (copy)")
+        self.assertEqual(page_copy.content, page.content)
+        self.assertEqual(page_copy.draft_name, "1.0")
+        self.assertEqual(page_copy.draft_summary, "summary")


### PR DESCRIPTION
The copy function is modified to create a copy named original_name+(copy) and with the same content.
Same as PR #351 v14.0