### PR TITLE
[FIX] document_page_approval: no "order" parameter in One2many field

### DIFF
--- a/document_page_approval/models/document_page.py
+++ b/document_page_approval/models/document_page.py
@@ -12,9 +12,7 @@ class DocumentPage(models.Model):
 
     _inherit = "document.page"
 
-    history_ids = fields.One2many(
-        order="approved_date DESC", domain=[("state", "=", "approved")]
-    )
+    history_ids = fields.One2many(domain=[("state", "=", "approved")])
 
     approved_date = fields.Datetime(
         "Approved Date",


### PR DESCRIPTION
There is no order parameter in the field One2many.