### PR TITLE
[14.0][FIX] document_page_reference: assure content or content_parsed is visible

### DIFF
--- a/document_page_reference/views/document_page.xml
+++ b/document_page_reference/views/document_page.xml
@@ -33,7 +33,7 @@
         <field name="inherit_id" ref="document_page.view_wiki_menu_form" />
         <field name="arch" type="xml">
             <field name="content" position="attributes">
-                <attribute name="invisible">1</attribute>
+                <attribute name="class">oe_edit_only</attribute>
             </field>
             <field name="content" position="before">
                 <field


### PR DESCRIPTION
This PR fixes two bugs:

- In menu pages, the content was invisible and thus couldn't be edited.
- In some pages, the content was badly processed (with no exception detected) and produced `<p>` content.