### PR TITLE
[FIX] document_page_approval:

### DIFF
--- a/document_page_approval/models/document_page_history.py
+++ b/document_page_approval/models/document_page_history.py
@@ -77,7 +77,7 @@ class DocumentPageHistory(models.Model):
                 users = self.env["res.users"].search(
                     [("groups_id", "in", guids), ("groups_id", "in", approver_gid.id)]
                 )
-                rec.message_subscribe([u.id for u in users])
+                rec.message_subscribe([u.partner_id.id for u in users])
                 rec.message_post_with_template(template.id)
             else:
                 # auto-approve if approval is not required


### PR DESCRIPTION
fixing issue when users ids send to message_subscribe instead of partner_id

reference: https://github.com/odoo/odoo/blob/14.0/addons/mail/models/mail_thread.py#L2694