### PR TITLE
[16.0][FIX] document_url: Change mimetype only if type=url

### DIFF
--- a/document_url/models/ir_attachment.py
+++ b/document_url/models/ir_attachment.py
@@ -8,6 +8,6 @@ class IrAttachment(models.Model):
     _inherit = "ir.attachment"
 
     def _compute_mimetype(self, values):
-        if values.get("url"):
+        if values.get("url") and values.get("type", "url") == "url":
             return "application/link"
         return super()._compute_mimetype(values)


### PR DESCRIPTION
FWP from 15.0: https://github.com/OCA/knowledge/pull/404

Other modules like web_pwa_oca uses url field for storing an indexed path for later being searched in the controller, so let's restrict the mimetype change if both url and type=url is set.

Please @pedrobaeza and @sergio-teruel can you review it?

@Tecnativa