### PR TITLE
[14.0][FIX] document_page_project: fix permissions for project users

### DIFF
--- a/document_page_project/models/project_project.py
+++ b/document_page_project/models/project_project.py
@@ -8,9 +8,16 @@ class ProjectProject(models.Model):
     _inherit = "project.project"
 
     document_page_ids = fields.One2many(
-        string="Wiki", comodel_name="document.page", inverse_name="project_id"
+        string="Wiki",
+        comodel_name="document.page",
+        inverse_name="project_id",
+        groups="knowledge.group_document_user",
     )
-    document_page_count = fields.Integer(compute="_compute_document_page_count")
+
+    document_page_count = fields.Integer(
+        compute="_compute_document_page_count",
+        groups="knowledge.group_document_user",
+    )
 
     def _compute_document_page_count(self):
         for rec in self:


### PR DESCRIPTION
Before this PR, users who could see projects but not knowledge were unable to access any project page due to the new fields linking knowledge documents and projects.