### PR TITLE
[14.0][FIX] document_page: Broken recomputation lead to invalid history head

### DIFF
--- a/document_page/models/document_page.py
+++ b/document_page/models/document_page.py
@@ -164,7 +164,10 @@ class DocumentPage(models.Model):
     def _compute_history_head(self):
         for rec in self:
             if rec.history_ids:
-                rec.history_head = rec.history_ids[0]
+                # do not rely on the history_ids default order here as odoo 14.0 does
+                # not seems to comply with the default model order when recomputing.
+                # fixing it by running a new sort (basically a new search).
+                rec.history_head = rec.history_ids.sorted()[0]
             else:
                 rec.history_head = False
 

--- a/document_page/tests/test_document_page.py
+++ b/document_page/tests/test_document_page.py
@@ -22,6 +22,10 @@ class TestDocumentPage(common.TransactionCase):
         self.assertEqual(len(page.history_ids), 1)
         page.content = "New content for Demo Page"
         self.assertEqual(len(page.history_ids), 2)
+        page.content = "Another new content for Demo Page"
+        self.assertEqual(len(page.history_ids), 3)
+        # ensure history head is the latest revision (default sort order is ID DESC)
+        self.assertEqual(page.history_head.id, max(page.history_ids.ids))
 
     def test_category_template(self):
         page = self.page_obj.create(


### PR DESCRIPTION
Knowledge revision system seems to be broken in Odoo 14.0