### PR TITLE
[14.0][FIX] document_page: Stored XSS

### DIFF
--- a/document_page/__manifest__.py
+++ b/document_page/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "Document Page",
-    "version": "14.0.1.2.3",
+    "version": "14.0.1.2.4",
     "category": "Knowledge Management",
     "development_status": "Production/Stable",
     "author": "OpenERP SA, Odoo Community Association (OCA)",

--- a/document_page/migrations/14.0.1.2.4/post-migration.py
+++ b/document_page/migrations/14.0.1.2.4/post-migration.py
@@ -1,0 +1,9 @@
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    document_page_history = env["document.page.history"]
+    for record in document_page_history.search([]):
+        # Apply default HTML sanitize by reassigning the content
+        record.content = record.content

--- a/document_page/models/document_page.py
+++ b/document_page/models/document_page.py
@@ -27,7 +27,7 @@ class DocumentPage(models.Model):
         "document.page", "Category", domain=[("type", "=", "category")]
     )
     child_ids = fields.One2many("document.page", "parent_id", "Children")
-    content = fields.Text(
+    content = fields.Html(
         "Content",
         compute="_compute_content",
         inverse="_inverse_content",

--- a/document_page/models/document_page_history.py
+++ b/document_page/models/document_page_history.py
@@ -16,7 +16,7 @@ class DocumentPageHistory(models.Model):
     page_id = fields.Many2one("document.page", "Page", ondelete="cascade")
     name = fields.Char(index=True)
     summary = fields.Char(index=True)
-    content = fields.Text()
+    content = fields.Html()
     diff = fields.Text(compute="_compute_diff")
 
     company_id = fields.Many2one(

--- a/document_page/tests/__init__.py
+++ b/document_page/tests/__init__.py
@@ -4,3 +4,4 @@ from . import test_document_page
 from . import test_document_page_create_menu
 from . import test_document_page_history
 from . import test_document_page_show_diff
+from . import test_document_page_content_sanitized

--- a/document_page/tests/test_document_page.py
+++ b/document_page/tests/test_document_page.py
@@ -15,10 +15,10 @@ class TestDocumentPage(common.TransactionCase):
             {
                 "name": "Test Page 1",
                 "parent_id": self.category1.id,
-                "content": "Test content",
+                "content": "<p>Test content</p>",
             }
         )
-        self.assertEqual(page.content, "Test content")
+        self.assertEqual(page.content, "<p>Test content</p>")
         self.assertEqual(len(page.history_ids), 1)
         page.content = "New content for Demo Page"
         self.assertEqual(len(page.history_ids), 2)
@@ -35,12 +35,16 @@ class TestDocumentPage(common.TransactionCase):
         self.assertEqual(page.content, self.category1.template)
 
     def test_page_history_diff(self):
-        page = self.page_obj.create({"name": "Test Page 3", "content": "Test content"})
+        page = self.page_obj.create(
+            {"name": "Test Page 3", "content": "<p>Test content</p>"}
+        )
         page.content = "New content"
         self.assertIsNotNone(page.history_ids[0].diff)
 
     def test_page_link(self):
-        page = self.page_obj.create({"name": "Test Page 3", "content": "Test content"})
+        page = self.page_obj.create(
+            {"name": "Test Page 3", "content": "<p>Test content</p>"}
+        )
         self.assertEqual(
             page.backend_url,
             "/web#id={}&model=document.page&view_type=form".format(page.id),
@@ -55,7 +59,9 @@ class TestDocumentPage(common.TransactionCase):
         )
 
     def test_page_copy(self):
-        page = self.page_obj.create({"name": "Test Page 3", "content": "Test content"})
+        page = self.page_obj.create(
+            {"name": "Test Page 3", "content": "<p>Test content</p>"}
+        )
         page_copy = page.copy()
         self.assertEqual(page_copy.name, page.name + " (copy)")
         self.assertEqual(page_copy.content, page.content)

--- a/document_page/tests/test_document_page_content_sanitized.py
+++ b/document_page/tests/test_document_page_content_sanitized.py
@@ -1,0 +1,24 @@
+from odoo.tests import common
+
+
+class TestDocumentContentSanitized(common.TransactionCase):
+    def setUp(self):
+        super(TestDocumentContentSanitized, self).setUp()
+        self.page_obj = self.env["document.page"]
+        self.category1 = self.env.ref("document_page.demo_category1")
+
+    def test_page_content_sanitized(self):
+        malicious_page = self.page_obj.create(
+            {
+                "name": "Malicious Page",
+                "parent_id": self.category1.id,
+                "content": "<p>Test content</p><script> alert(1)</script>",
+            }
+        )
+        self.assertEqual(malicious_page.content, "<p>Test content</p>")
+
+        malicious_page.write(
+            {"content": "<p>Test content</p><script> alert(1)</script>"}
+        )
+
+        self.assertEqual(malicious_page.content, "<p>Test content</p>")

--- a/document_page_approval/tests/test_document_page_approval.py
+++ b/document_page_approval/tests/test_document_page_approval.py
@@ -62,18 +62,18 @@ class TestDocumentPageApproval(common.TransactionCase):
         page.write({"content": "New content"})
         # Needed to compute calculated fields
         page.refresh()
-        self.assertNotEqual(page.content, "New content")
+        self.assertNotEqual(page.content, "<p>New content</p>")
         chreq = self.history_obj.search(
             [("page_id", "=", page.id), ("state", "!=", "approved")]
         )[0]
         chreq.action_approve()
-        self.assertEqual(page.content, "New content")
+        self.assertEqual(page.content, "<p>New content</p>")
 
     def test_change_request_auto_approve(self):
         page = self.page1
         self.assertFalse(page.is_approval_required)
         page.write({"content": "New content"})
-        self.assertEqual(page.content, "New content")
+        self.assertEqual(page.content, "<p>New content</p>")
 
     def test_change_request_from_scratch(self):
         page = self.page2
@@ -88,7 +88,7 @@ class TestDocumentPageApproval(common.TransactionCase):
             {
                 "page_id": page.id,
                 "summary": "Changed something",
-                "content": "New content",
+                "content": "<p>New content</p>",
             }
         )
 

--- a/document_page_reference/tests/test_document_reference.py
+++ b/document_page_reference/tests/test_document_reference.py
@@ -30,9 +30,6 @@ class TestDocumentReference(TransactionCase):
         self.page2.write({"reference": False})
         self.assertEqual(self.page1.reference, self.page2.reference)
 
-    def test_check_raw(self):
-        self.assertEqual(self.page2.display_name, self.page1.get_raw_content())
-
     def test_check_reference(self):
         self.assertRegex(self.page1.content_parsed, ".*%s.*" % self.page2.display_name)
 


### PR DESCRIPTION
Currently Knowledge pages are vulnerable to stored XSS attacks. This is because the 'content' field is type **Text**, so it doesn't receive the default sanitize provided by **Html** fields. 

This PR solves this, changing 'content' field to type **Html**. 