### PR TITLE
[16.0][FIX] attachment_zipped_download: create temporary file to stream

### DIFF
--- a/attachment_zipped_download/controllers/main.py
+++ b/attachment_zipped_download/controllers/main.py
@@ -13,9 +13,11 @@ class AttachmentZippedDownloadController(http.Controller):
             return
         list_ids = map(int, ids.split(","))
         out_file = request.env["ir.attachment"].browse(list_ids)._create_temp_zip()
-        return http.send_file(
-            filepath_or_fp=out_file,
+        stream = http.Stream(
+            type="data",
+            data=out_file.getvalue(),
             mimetype="application/zip",
             as_attachment=True,
-            filename=_("attachments.zip"),
+            download_name=_("attachments.zip"),
         )
+        return stream.get_response()


### PR DESCRIPTION
Despite accurately getting the size from the BytesIO object, Werkzeug doesn't stream its content.
This updates the code to use Odoo's http.Stream class.

Fixes https://github.com/OCA/knowledge/issues/406