### PR TITLE
16.0[IMP]document_page: menu_parent_id context domain of menu creation

### DIFF
--- a/document_page/README.rst
+++ b/document_page/README.rst
@@ -93,6 +93,7 @@ Trobz
 * `Sygel <https://www.sygel.es>`_:
 
   * Ángel García de la Chica Herrera
+  * Alberto Martínez Rodríguez
 
 Other credits
 ~~~~~~~~~~~~~

--- a/document_page/models/__init__.py
+++ b/document_page/models/__init__.py
@@ -2,3 +2,4 @@
 
 from . import document_page
 from . import document_page_history
+from . import ir_ui_menu

--- a/document_page/models/ir_ui_menu.py
+++ b/document_page/models/ir_ui_menu.py
@@ -1,0 +1,27 @@
+# Copyright 2024 Alberto Martínez <alberto.martinez@sygel.es>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class IrUiMenu(models.Model):
+    _inherit = "ir.ui.menu"
+
+    def _visible_menu_ids(self, debug=False):
+        visible_ids = super()._visible_menu_ids(debug)
+        if self._context.get("ir.ui.menu.authorized_list"):
+            # Add the authorized by groups menus that does not have an action
+            menus = (
+                self.with_context(**{"ir.ui.menu.full_list": True}).search([]).sudo()
+            )
+            groups = (
+                self.env.user.groups_id
+                if not debug
+                else self.env.user.groups_id - self.env.ref("base.group_no_one")
+            )
+            authorized_menus = menus.filtered(
+                lambda m: not m.groups_id or m.groups_id and groups
+            )
+            authorized_folder_menus = authorized_menus.filtered(lambda m: not m.action)
+            visible_ids = visible_ids.union(authorized_folder_menus.ids)
+        return visible_ids

--- a/document_page/tests/test_document_page_create_menu.py
+++ b/document_page/tests/test_document_page_create_menu.py
@@ -27,3 +27,17 @@ class TestDocumentPageCreateMenu(common.TransactionCase):
         ).default_get(fields_list)
 
         self.assertEqual(res["menu_name"], "Odoo 15.0 Functional Demo")
+
+    def test_page_menu_parent_id_context(self):
+        """Test page menu parent_id context."""
+        menu_parent = self.env["ir.ui.menu"].create({"name": "Test Folder Menu"})
+        context_results = (
+            self.env["ir.ui.menu"]
+            .with_context(**{"ir.ui.menu.authorized_list": True})
+            .search([("id", "=", menu_parent.id)])
+        )
+        no_context_results = self.env["ir.ui.menu"].search(
+            [("id", "=", menu_parent.id)]
+        )
+        self.assertEqual(context_results[:1].id, menu_parent.id)
+        self.assertEqual(any(no_context_results), False)

--- a/document_page/wizard/document_page_create_menu.xml
+++ b/document_page/wizard/document_page_create_menu.xml
@@ -8,7 +8,10 @@
             <form>
                 <group string="Menu Information">
                     <field name="menu_name" />
-                    <field name="menu_parent_id" />
+                    <field
+                        name="menu_parent_id"
+                        context="{'ir.ui.menu.authorized_list': True}"
+                    />
                 </group>
                 <footer>
                     <button


### PR DESCRIPTION
On the document_page module, there is one use case when we can't correctly create a menu item for a page.

This case occurs when we want to create the document menu under a new "Documentation" menu. Example:

Sales
    - Documentation
        - Page 1
        - Page 2
        ...

Steps to reproduce:

1. Create the "Documentation" parent menu, as it is a folder we dont fill the 'action' field.
2. Go to a knowledge document form, and select action -> create mene. You can see that the "Documentation" menu does not appear on the parent menu's list.

![Captura de pantalla de 2024-01-09 13-59-25](https://github.com/OCA/knowledge/assets/45785416/c9ee81e2-3f53-43b7-9767-dedcbd3aba43)


The reason of the problem is that, by default, we only can see the menus that have an action, or a child with actions. 
To see all, odoo gives a context parameter that can be placed on the field: context="{'ir.ui.menu.full_list': True}".
However, with this context on the menu_parent_id of the document_page create menu wizard the document users are able to see menus they must not be able to see due to permission groups; and they can create aditional menus under the unauthorized ones.
To solve this, a new context parameter has been created: "ir.ui.menu.authorized_list", that allows to see all menus, except the unauthorized by permission groups

PD: A unit test is in progress
