### PR TITLE
[15.0][FIX] document_page: Fix quick create and edit form category on pages

### DIFF
--- a/document_page/views/document_page.xml
+++ b/document_page/views/document_page.xml
@@ -64,7 +64,7 @@
                                         name="parent_id"
                                         required="True"
                                         string="Category"
-                                        context="{'default_type':'category'}"
+                                        context="{'default_type':'category', 'form_view_ref': 'document_page.view_category_form'}"
                                     />
                                     <field
                                         name="company_id"


### PR DESCRIPTION
- When quickly create and edit Category on Knowledge/Pages/Pages opens Page form view insted of Category form view.

![2024-01-10 09 45 47](https://github.com/OCA/knowledge/assets/143796894/51c0e773-7020-401c-8d8b-73ee3fefc287)

@Tecnativa
TT47041

@pedrobaeza @pilarvargas-tecnativa 