### PR TITLE
[16.0][FIX] document_page: Fix quick create and edit form category on pages

### DIFF
--- a/document_page/views/document_page.xml
+++ b/document_page/views/document_page.xml
@@ -64,7 +64,7 @@
                                         name="parent_id"
                                         required="True"
                                         string="Category"
-                                        context="{'default_type':'category'}"
+                                        context="{'default_type':'category', 'form_view_ref': 'document_page.view_category_form'}"
                                     />
                                     <field
                                         name="company_id"


### PR DESCRIPTION
- When quickly create and edit Category on Knowledge/Pages/Pages opens Page form view insted of Category form view.

![2024-01-10 09 45 47](https://github.com/OCA/knowledge/assets/143796894/82fdb348-2df7-4fee-9738-367df7d553b6)

@Tecnativa
TT47041

@pedrobaeza @pilarvargas-tecnativa 
