### PR TITLE
[16.0][FIX] document_page: Change web_ribbon text to title to make it translatable

### DIFF
--- a/document_page/views/document_page.xml
+++ b/document_page/views/document_page.xml
@@ -40,7 +40,7 @@
                     <div name="button_box" id="button_box" class="oe_button_box" />
                     <widget
                         name="web_ribbon"
-                        text="Archived"
+                        title="Archived"
                         bg_color="bg-danger"
                         attrs="{'invisible': [('active', '=', True)]}"
                     />


### PR DESCRIPTION
FWP from 15.0: https://github.com/OCA/knowledge/pull/455

Change web_ribbon text to title to make it translatable

@Tecnativa