### PR TITLE
[16.0][FIX] document_page: draft summary widget

### DIFF
--- a/document_page/views/document_page.xml
+++ b/document_page/views/document_page.xml
@@ -88,6 +88,7 @@
                                         name="draft_summary"
                                         placeholder="eg: Changed ... for ..."
                                         required="True"
+                                        widget="text"
                                     />
                                 </group>
                             </group>


### PR DESCRIPTION
This change is so that the draft_summary field, if it has very long text, is not cut off and can be seen.