### PR TITLE
[14.0] [FIX] attachment_preview: fix get_binary_extension

### DIFF
--- a/attachment_preview/models/ir_attachment.py
+++ b/attachment_preview/models/ir_attachment.py
@@ -41,6 +41,8 @@ class IrAttachment(models.Model):
         ids_to_browse = [_id for _id in ids_to_browse if _id not in result]
         for this in self.env[model].with_context(bin_size=True).browse(ids_to_browse):
             result[this.id] = False
+            if not this[binary_field]:
+                continue
             try:
                 import magic
 

--- a/attachment_preview/tests/test_attachment_preview.py
+++ b/attachment_preview/tests/test_attachment_preview.py
@@ -35,3 +35,11 @@ class TestAttachmentPreview(TransactionCase):
             "ir.module.module", module.id, "icon_image"
         )
         self.assertTrue(res3)
+
+        module = (
+            self.env["ir.ui.menu"].search([]).filtered(lambda m: not m.web_icon_data)[0]
+        )
+        res4 = self.env["ir.attachment"].get_binary_extension(
+            "ir.ui.menu", module.id, "web_icon_data"
+        )
+        self.assertFalse(res4)


### PR DESCRIPTION
Without this fix, opening a `ir.ui.menu` record from the "Technical" menu with an empty icon, would raise an error.

Also added a couple of test lines that would fail without this.

Fixed pre-commit in https://github.com/OCA/knowledge/pull/462