### PR TITLE
[FIX] incorrect check for users to send notification

### DIFF
--- a/document_page_approval/models/document_page_history.py
+++ b/document_page_approval/models/document_page_history.py
@@ -78,7 +78,7 @@ class DocumentPageHistory(models.Model):
                 users = self.env["res.users"].search(
                     [("groups_id", "in", guids), ("groups_id", "in", approver_gid.id)]
                 )
-                rec.message_subscribe([u.id for u in users])
+                rec.message_subscribe([u.id for u in users.partner_id])
                 rec.message_post_with_template(template.id)
             else:
                 # auto-approve if approval is not required


### PR DESCRIPTION
Error document_page_approval->document_page_history.py
line 81:
rec.message_subscribe([u.id for u in users]) # WRONG
rec.message_subscribe([u.id for u in users.partner_id]) # CORRECT

The incorrect version of the code checked the sending of the notification based on the user id, the problem is that the notifications should be checked against the partner_id as it may be different from the user_id and this sometimes sends messages to the wrong contacts.