### PR TITLE
[14.0][REF] document_page: set title attribute in <i> tag

### DIFF
--- a/document_page/views/document_page_category.xml
+++ b/document_page/views/document_page_category.xml
@@ -127,13 +127,17 @@
                                         >
                                             <i
                                                 t-if="!record.image.raw_value"
+                                                title="Folder"
                                                 class="o_kanban_image fa fa-folder-open"
                                             />
                                         </span>
                                     </t>
                                     <t t-if="record.type.raw_value == 'content'">
                                         <span style="font-size: 64px; color: lightgray">
-                                            <i class="o_kanban_image fa fa-file" />
+                                            <i
+                                                title="File"
+                                                class="o_kanban_image fa fa-file"
+                                            />
                                         </span>
                                     </t>
                                 </div>


### PR DESCRIPTION
This PR aims to refactor the tag `<i>` to resolve a warning present in the log:

`2024-04-19 19:11:20,677 1 WARNING odoo.addons.base.models.ir_ui_view: A <i> with fa class (o_kanban_image fa fa-file) must have title in its tag, parents, descendants or have text`

`2024-04-19 19:11:20,675 1 WARNING odoo.addons.base.models.ir_ui_view: A <i> with fa class (o_kanban_image fa fa-folder-open) must have title in its tag, parents, descendants or have text`

cc @marcelsavegnago @WesleyOliveira98 @Matthwhy