### PR TITLE
[14.0][FIX]attachment_preview: get preview for files in db only

### DIFF
--- a/attachment_preview/readme/CONTRIBUTORS.rst
+++ b/attachment_preview/readme/CONTRIBUTORS.rst
@@ -1,2 +1,3 @@
 * Holger Brunn <mail@hunki-enterprises.com>
 * Dennis Sluijk <d.sluijk@onestein.nl>
+* Sebastiano Picchi <sebastiano.picchi@pytech.it>

--- a/attachment_preview/static/src/js/attachment_preview.js
+++ b/attachment_preview/static/src/js/attachment_preview.js
@@ -334,7 +334,9 @@ odoo.define("/attachment_preview/static/src/js/attachment_preview.js", function 
 
                 attachments = _.object(
                     attachments.map((att) => {
-                        return parseInt(att.localId.slice(16), 10);
+                        const tmp_id = parseInt(att.localId.slice(16), 10);
+                        if (tmp_id > 0) return tmp_id;
+                        return null;
                     }),
                     attachments.map((at) => {
                         if (at.defaultSource) {


### PR DESCRIPTION
In a few cases, when a user uploads files such as PDFs, when the client tries to get the preview, the file may not be saved yet.

This results in the following error
![image001](https://github.com/OCA/knowledge/assets/38473030/30d97467-3e42-49d9-8354-ce5407be37e9)

With this check we fetch only the previews of those files we know the id of.