### PR TITLE
[16.0][IMP] document_page: Set class oe_title to show the h1 field name filling more width

### DIFF
--- a/document_page/views/document_page.xml
+++ b/document_page/views/document_page.xml
@@ -46,9 +46,11 @@
                     />
                     <field name="active" invisible="1" />
                     <field name="type" invisible="1" />
-                    <h1>
-                        <field name="name" placeholder="Name" />
-                    </h1>
+                    <div class="oe_title">
+                        <h1>
+                            <field name="name" placeholder="Name" />
+                        </h1>
+                    </div>
                     <field
                         name="content"
                         widget="html"


### PR DESCRIPTION
cc @Tecnativa TT50562

ping @pedrobaeza @carolinafernandez-tecnativa 

Before this changes
![image](https://github.com/user-attachments/assets/9908670f-7496-444a-b69d-bb41e4769cee)

After
![image](https://github.com/user-attachments/assets/8a739115-5ef2-4981-b133-f13be7e7c483)
