### PR TITLE
[17.0][FIX] document_url: Fix Download attachment component

### DIFF
--- a/document_url/static/src/js/url.esm.js
+++ b/document_url/static/src/js/url.esm.js
@@ -52,6 +52,11 @@ patch(AttachmentList.prototype, {
      *
      * @returns {String}
      */
+    canDownload(attachment) {
+        return (
+            super.canDownload(attachment) && attachment.mimetype != "application/link"
+        );
+    },
     get attachmentUrl() {
         return url("/web/content", {
             id: this.attachment.id,

--- a/document_url/static/src/xml/url.xml
+++ b/document_url/static/src/xml/url.xml
@@ -31,12 +31,6 @@
     </t>
     <t t-inherit="mail.AttachmentList" t-inherit-mode="extension">
         <xpath
-            expr="//div[contains(@class, 'o-mail-AttachmentCard-aside')]//button[@title='Download']"
-            position="attributes"
-        >
-            <attribute name="t-if">attachment.mimetype != 'application/link'</attribute>
-        </xpath>
-        <xpath
             expr="//div[hasclass('o-mail-AttachmentCard-aside')]//button[@title='Download']"
             position="after"
         >


### PR DESCRIPTION
This commit (https://github.com/odoo/odoo/commit/366676cafdce00d55823c6daf41452b0c2373e4d) move download buttons into a sub-component. 
I modified the module behavior to use canDownload() method instead of adding a t-if in the view and prevent the chatter component from breaking when the message has attachments.