### PR TITLE
[17.0][OU-FIX] document_page_access_group: use env in openupgrade load_data instead of cr

### DIFF
--- a/document_page_access_group/migrations/17.0.1.1.0/post-migration.py
+++ b/document_page_access_group/migrations/17.0.1.1.0/post-migration.py
@@ -6,7 +6,7 @@ from openupgradelib import openupgrade
 @openupgrade.migrate()
 def migrate(env, version):
     openupgrade.load_data(
-        env.cr,
+        env,
         "document_page_access_group",
         "migrations/17.0.1.1.0/noupdate_changes.xml",
     )


### PR DESCRIPTION
Use env in openupgrade load_data instead of cr

As stated in https://github.com/OCA/openupgradelib/blob/master/openupgradelib/openupgrade.py#L297, the param should `env`, instead of the cursor

@Tecnativa