### PR TITLE
[16.0][IMP] document_page: extend follower to childs

### DIFF
--- a/document_page/models/document_page.py
+++ b/document_page/models/document_page.py
@@ -190,3 +190,49 @@ class DocumentPage(models.Model):
             draft_summary=_("summary"),
         )
         return super().copy(default=default)
+
+    @api.model
+    def create(self, vals):
+        """Automatically make the category followers follow the new page"""
+        res = super().create(vals)
+
+        if res.type == "content" and res.parent_id and res.parent_id.type == "category":
+            category = res.parent_id
+            category_followers = category.message_partner_ids.ids
+
+            if category_followers:
+                res.message_subscribe(partner_ids=category_followers)
+
+        return res
+
+    def message_subscribe(self, partner_ids, subtype_ids=None):
+        res = super().message_subscribe(partner_ids, subtype_ids)
+        self._toggle_follow_category_documents()
+
+        return res
+
+    def message_unsubscribe(self, partner_ids):
+        res = super().message_unsubscribe(partner_ids)
+        self._toggle_follow_category_documents()
+
+        return res
+
+    def _toggle_follow_category_documents(self):
+        """
+        Follow/unfollow all documents in a category
+        based on the category's follower status.
+        """
+        for rec in self:
+            if rec.type != "category":
+                continue
+
+            related_docs = self.env["document.page"].search(
+                [("type", "=", "content"), ("parent_id", "=", rec.id)]
+            )
+
+            partner_ids = [self.env.user.partner_id.id]
+
+            if not rec.message_is_follower:
+                related_docs.message_unsubscribe(partner_ids)
+            else:
+                related_docs.message_subscribe(partner_ids)

--- a/document_page/tests/__init__.py
+++ b/document_page/tests/__init__.py
@@ -4,3 +4,4 @@ from . import test_document_page
 from . import test_document_page_create_menu
 from . import test_document_page_history
 from . import test_document_page_show_diff
+from . import test_document_page_followers

--- a/document_page/tests/test_document_page_followers.py
+++ b/document_page/tests/test_document_page_followers.py
@@ -1,0 +1,85 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo.tests import common
+
+
+class TestDocumentPageFollowers(common.TransactionCase):
+    def setUp(self):
+        super().setUp()
+
+        self.user_1 = self.env["res.users"].create(
+            {
+                "name": "Test User 1",
+                "login": "test_user_1",
+                "email": "user1@test.com",
+            }
+        )
+
+        self.user_2 = self.env["res.users"].create(
+            {
+                "name": "Test User 2",
+                "login": "test_user_2",
+                "email": "user2@test.com",
+            }
+        )
+
+        self.category = self.env["document.page"].create(
+            {
+                "name": "Test Category",
+                "type": "category",
+            }
+        )
+
+        self.content_page = self.env["document.page"].create(
+            {
+                "name": "Test Content Page",
+                "type": "content",
+                "parent_id": self.category.id,
+            }
+        )
+
+    def test_auto_subscribe_new_page(self):
+        """When creating a page in a category with followers, they are subscribed"""
+
+        self.category.message_subscribe(
+            partner_ids=[self.user_1.partner_id.id, self.user_2.partner_id.id]
+        )
+
+        new_page = self.env["document.page"].create(
+            {
+                "name": "New Auto-Subscribed Page",
+                "type": "content",
+                "parent_id": self.category.id,
+            }
+        )
+
+        followers = new_page.message_partner_ids.ids
+
+        self.assertIn(self.user_1.partner_id.id, followers)
+        self.assertIn(self.user_2.partner_id.id, followers)
+
+    def test_follow_category_subscribes_documents(self):
+        """Follow a category should subscribe to its existing pages"""
+        self.category.message_subscribe([self.user_1.partner_id.id])
+
+        self.assertIn(
+            self.user_1.partner_id.id,
+            self.content_page.parent_id.message_partner_ids.ids,
+        )
+
+    def test_unfollow_category_unsubscribes_documents(self):
+        """Unfollowing a category should unsubscribe from its existing pages"""
+        self.category.message_subscribe([self.user_1.partner_id.id])
+        self.category.message_unsubscribe([self.user_1.partner_id.id])
+
+        self.assertNotIn(
+            self.user_1.partner_id.id,
+            self.content_page.parent_id.message_partner_ids.ids,
+        )
+
+    def test_no_auto_subscribe_without_category(self):
+        """Pages without a category should not have automatic subscriptions"""
+        new_page = self.env["document.page"].create(
+            {"name": "Orphan Page", "type": "content"}
+        )
+
+        self.assertFalse(new_page.message_partner_ids)


### PR DESCRIPTION
This implementation automates follower management for knowledge pages within categories. When a "content" page is created under a category with followers, those followers are automatically subscribed to the new page. Additionally, following/unfollowing a category propagates/revokes subscriptions to all its existing documents. Includes tests validating:


- Automatic subscription when creating pages in categories with followers.

- Subscription synchronization when following/unfollowing categories.

- Correct behavior for pages without a parent category.