### PR TITLE
[17.0][FIX] document_page_approval: Add Change Request Manager rule

### DIFF
--- a/document_page_approval/security/document_page_security.xml
+++ b/document_page_approval/security/document_page_security.xml
@@ -36,4 +36,17 @@
         <field name="perm_unlink" eval="True" />
         <field name="perm_create" eval="True" />
     </record>
+    <record model="ir.rule" id="rule_change_request_manager">
+        <field name="name">Change Request Manager</field>
+        <field name="model_id" ref="model_document_page_history" />
+        <field
+            name="groups"
+            eval="[(6, 0, [ref('document_page.group_document_manager')])]"
+        />
+        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="perm_read" eval="True" />
+        <field name="perm_write" eval="True" />
+        <field name="perm_unlink" eval="True" />
+        <field name="perm_create" eval="True" />
+    </record>
 </odoo>

--- a/document_page_approval/views/document_page_approval.xml
+++ b/document_page_approval/views/document_page_approval.xml
@@ -45,6 +45,7 @@
                         type="object"
                         string="Back to draft"
                         invisible="(not am_i_owner or not am_i_approver) and (state not in ('cancelled', 'to approve'))"
+                        groups="document_page.group_document_manager"
                     />
                     <field name="am_i_owner" invisible="1" />
                     <field name="am_i_approver" invisible="1" />


### PR DESCRIPTION
FWP from 16.0: https://github.com/OCA/knowledge/pull/530

Add Change Request Manager rule

Steps to reproduce the error:
- Modify the content of a page (with a different user).
- Go to the Change request menu and Cancel the change.
- Click on the "Back to draft" button.
- An error will be displayed

Please @pilarvargas-tecnativa and @pedrobaeza can you review it?

@Tecnativa TT55569