### PR TITLE
[16.0][FIX]document_page_project: fixed permissions to view content

### DIFF
--- a/document_page_project/views/project_project_views.xml
+++ b/document_page_project/views/project_project_views.xml
@@ -9,6 +9,7 @@
                     class="o_project_kanban_box"
                     name="%(action_document_page_projects)d"
                     type="action"
+                    groups="document_knowledge.group_document_user"
                 >
                     <div>
                         <b>
@@ -35,6 +36,7 @@
                     type="action"
                     name="%(action_document_page_projects)d"
                     icon="fa-book"
+                    groups="document_knowledge.group_document_user"
                 >
                     <field
                         string="Wiki Pages"


### PR DESCRIPTION
User with only permission on Services/Project have a pop-up error when entering Projects/projects:
![immagine](https://github.com/user-attachments/assets/e67ae5d6-1b0e-4e09-a16b-dfc09baa7f45)

With the fix, user enter correctly in Projects/Projects, but can't see Knowledge buttons.