### PR TITLE
[IMP] document_page: Wrap diff view, set wrapping via ir.config_param…

### DIFF
--- a/document_page/__manifest__.py
+++ b/document_page/__manifest__.py
@@ -19,6 +19,7 @@
     "license": "AGPL-3",
     "depends": ["mail", "document_knowledge"],
     "data": [
+        "data/ir_config_parameter_data.xml",
         "security/document_page_security.xml",
         "security/ir.model.access.csv",
         "wizard/document_page_create_menu.xml",

--- a/document_page/data/ir_config_parameter_data.xml
+++ b/document_page/data/ir_config_parameter_data.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo noupdate="1">
+
+<record id="document_page_wrapcolumn" model="ir.config_parameter">
+    <field name="key">document_page.wrapcolumn</field>
+    <field name="value">40</field>
+</record>
+
+</odoo>

--- a/document_page/models/document_page_history.py
+++ b/document_page/models/document_page_history.py
@@ -54,10 +54,12 @@ class DocumentPageHistory(models.Model):
         text2 = text2.replace("</p><p>", "</p>\r\n<p>")
         line1 = text1.splitlines(True)
         line2 = text2.splitlines(True)
+        params = self.env["ir.config_parameter"].sudo()
+        wrapcolumn = int(params.get_param("document_page.wrapcolumn", None))
         if line1 == line2:
             return _("There are no changes in revisions.")
         else:
-            diff = difflib.HtmlDiff()
+            diff = difflib.HtmlDiff(wrapcolumn=wrapcolumn)
             return diff.make_table(
                 line1,
                 line2,


### PR DESCRIPTION
…eter

Use wrapcolumn when calling HtmlDiff to view long line changes in one screen. Wrapping is set to a sane 40 columns default, but can be overriden by changing document_page.wrapcolumn config_parameter To restore original behaviour, delete document_page.wrapcolumn key in ir.config_parameter