### PR TITLE
[16.0][FIX] document_page: Don't change last history name and summary…

### DIFF
--- a/document_page/models/document_page.py
+++ b/document_page/models/document_page.py
@@ -36,15 +36,15 @@ class DocumentPage(models.Model):
     draft_name = fields.Char(
         string="Name",
         help="Name for the changes made",
-        related="history_head.name",
-        readonly=False,
+        compute="_compute_content",
+        inverse="_inverse_content",
     )
 
     draft_summary = fields.Char(
         string="Summary",
         help="Describe the changes made",
-        related="history_head.summary",
-        readonly=False,
+        compute="_compute_content",
+        inverse="_inverse_content",
     )
 
     template = fields.Html(
@@ -132,12 +132,18 @@ class DocumentPage(models.Model):
         for rec in self:
             if rec.type == "category":
                 rec.content = rec._get_page_index(link=False)
+                rec.draft_name = False
+                rec.draft_summary = False
             else:
                 if rec.history_head:
                     rec.content = rec.history_head.content
+                    rec.draft_name = rec.history_head.name
+                    rec.draft_summary = rec.history_head.summary
                 else:
                     # html widget's default, so it doesn't trigger ghost save
                     rec.content = self._HTML_WIDGET_DEFAULT_VALUE
+                    rec.draft_name = False
+                    rec.draft_summary = False
 
     def _inverse_content(self):
         for rec in self:


### PR DESCRIPTION
… when creating new revision of page.

Fixes an issue where editing a document.page and changing name and/or summary (to create a new revision) also changes name and summary of the history_head.

draft_name and draft_summary are now computed fields (based on history_head) but have set the inverse without actually setting the value, to allow setting them when creating a new draft page.

The issue is prominently evident when using document_page_approval where the name/summary for the new draft also change the last approved version (aka history_head) which should not happen.