### PR TITLE
[18.0] [IMP] document_page_access_group: update contributors from document_page_group

### DIFF
--- a/document_page_access_group/README.rst
+++ b/document_page_access_group/README.rst
@@ -64,6 +64,7 @@ Authors
 -------
 
 * Sygel
+* Creu Blanca
 
 Contributors
 ------------
@@ -78,6 +79,10 @@ Contributors
 - `Heliconia Solutions Pvt. Ltd. <https://www.heliconia.io>`__
 
   - Bhavesh Heliconia
+
+- `Dixmit <https://www.dixmit.com>`__:
+
+  - Enric Tobella
 
 Maintainers
 -----------

--- a/document_page_access_group/__manifest__.py
+++ b/document_page_access_group/__manifest__.py
@@ -7,7 +7,7 @@
     "version": "18.0.1.0.0",
     "category": "document_knowledge",
     "website": "https://github.com/OCA/knowledge",
-    "author": "Sygel, Odoo Community Association (OCA)",
+    "author": "Sygel, Creu Blanca, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "application": False,
     "installable": True,

--- a/document_page_access_group/readme/CONTRIBUTORS.md
+++ b/document_page_access_group/readme/CONTRIBUTORS.md
@@ -5,3 +5,6 @@
   * Víctor Martínez
 - [Heliconia Solutions Pvt. Ltd.](https://www.heliconia.io)
   - Bhavesh Heliconia
+
+- [Dixmit](https://www.dixmit.com):
+  - Enric Tobella

--- a/document_page_access_group/static/description/index.html
+++ b/document_page_access_group/static/description/index.html
@@ -410,6 +410,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <h2><a class="toc-backref" href="#toc-entry-4">Authors</a></h2>
 <ul class="simple">
 <li>Sygel</li>
+<li>Creu Blanca</li>
 </ul>
 </div>
 <div class="section" id="contributors">
@@ -423,6 +424,10 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </li>
 <li><a class="reference external" href="https://www.heliconia.io">Heliconia Solutions Pvt. Ltd.</a><ul>
 <li>Bhavesh Heliconia</li>
+</ul>
+</li>
+<li><a class="reference external" href="https://www.dixmit.com">Dixmit</a>:<ul>
+<li>Enric Tobella</li>
 </ul>
 </li>
 </ul>


### PR DESCRIPTION
Due to issue #502, document_page_group will not be continued, so the contributors can be maintained in the merged module