### PR TITLE
[18.0][FIX] document_page_approval: Avoid errors when creating a page history and send mail

### DIFF
--- a/document_page_approval/models/document_page_history.py
+++ b/document_page_approval/models/document_page_history.py
@@ -4,6 +4,7 @@
 
 from odoo import fields, models
 from odoo.exceptions import UserError
+from odoo.tools.misc import clean_context
 from odoo.tools.translate import _
 
 
@@ -80,7 +81,10 @@ class DocumentPageHistory(models.Model):
                     [("groups_id", "in", guids), ("groups_id", "in", approver_gid.id)]
                 )
                 rec.message_subscribe(partner_ids=users.mapped("partner_id").ids)
-                rec.message_post_with_source(template)
+                # pylint: disable=W8121
+                rec.with_context(
+                    clean_context(self.env.context)
+                ).message_post_with_source(template)
             else:
                 # auto-approve if approval is not required
                 rec.action_approve()

--- a/document_page_approval/tests/test_document_page_approval.py
+++ b/document_page_approval/tests/test_document_page_approval.py
@@ -1,6 +1,7 @@
 from odoo import Command
 from odoo.exceptions import UserError
 from odoo.tests import new_test_user
+from odoo.tools import mute_logger
 
 from odoo.addons.base.tests.common import BaseCommon
 
@@ -53,6 +54,7 @@ class TestDocumentPageApproval(BaseCommon):
         self.assertTrue(page.has_changes_pending_approval)
         self.assertEqual(len(page.history_ids), 0)
 
+    @mute_logger("odoo.models.unlink")
     def test_change_request_approve(self):
         """Test that an approver can approve a change request."""
         page = self.page2
@@ -72,6 +74,11 @@ class TestDocumentPageApproval(BaseCommon):
         self.assertEqual(chreq.state, "approved")
         self.assertEqual(chreq.content, page.content)
 
+        # Remove the linked mail.message and define a specific context to simulate that
+        # when accessing from the category smart button, there is no error when creating
+        # the history and sending the email
+        self.env["mail.message"].browse(page.parent_id.id).unlink()
+        page = page.with_context(default_parent_id=page.parent_id.id)
         # Create new change request
         page.write({"content": "<p>New content</p>"})
         page.invalidate_model()  # Recompute fields
@@ -90,6 +97,7 @@ class TestDocumentPageApproval(BaseCommon):
         page.write({"content": "<p>New content</p>"})
         self.assertEqual(page.content, "<p>New content</p>")
 
+    @mute_logger("odoo.models.unlink")
     def test_change_request_from_scratch(self):
         """Test a full change request lifecycle from draft to approval."""
         page = self.page2
@@ -164,6 +172,7 @@ class TestDocumentPageApproval(BaseCommon):
             self.page2.with_user(self.user2).can_user_approve_this_page(self.user2)
         )
 
+    @mute_logger("odoo.models.unlink")
     def test_pending_approval_detection(self):
         """Ensure the system detects pending approval changes"""
         # Reset page2 by removing previous history


### PR DESCRIPTION
Avoid errors when creating a page history and end mail

Example use case:
- Modify the Odoo Features category, check Require approval, and set Approver group > Administration / Access Rights
- Modify the Marc Demo user and define Document Knowledge > Editor permissions
- Go to the Odoo Features category and, taking into account the ID, delete the mail_message record table with the same ID from the database
- With the Marc Demo user, go to the Knowledge > Odoo Features menu and enter the Odoo 15.0 Functional Demo page (it is important to follow these specific steps)
- Modify the page and save

Before this change, an error could occur because the action https://github.com/OCA/knowledge/blob/0881d75a35e7fc2f814110df4878177e805e589b/document_page/views/document_page_category. xml#L83C17-L83C42 defined a default_parent_id=x (page category ID) if there was no mail_message linked to that category ID; now the value of default_parent_id is removed to avoid this specific error.

Please @pedrobaeza and @pilarvargas-tecnativa can you review it?

@Tecnativa TT61290