### PR TITLE
[19.0][FIX] demo data migration to v19.0

### DIFF
--- a/document_knowledge/demo/document_knowledge.xml
+++ b/document_knowledge/demo/document_knowledge.xml
@@ -2,7 +2,7 @@
 <odoo noupdate="1">
     <record id="base.user_demo" model="res.users">
         <field
-            name="groups_id"
+            name="group_ids"
             eval="[(4,ref('document_knowledge.group_document_user'))]"
         />
     </record>

--- a/document_page/demo/document_page.xml
+++ b/document_page/demo/document_page.xml
@@ -3,7 +3,7 @@
     <record id="base.user_demo" model="res.users">
         <field
             eval="[(4, ref('document_knowledge.group_document_user'))]"
-            name="groups_id"
+            name="group_ids"
         />
     </record>
 


### PR DESCRIPTION
Field `groups_id` for the model `res.users` was renamed to `group_ids`.
This PR includes a fix for the demo data.