### PR TITLE
[18.0][FIX] enable document reference link generation

### DIFF
--- a/document_page_reference/models/document_page.py
+++ b/document_page_reference/models/document_page.py
@@ -50,13 +50,30 @@ class DocumentPage(models.Model):
 
     def get_content(self):
         self.ensure_one()
-        content_parsed = raw = self.content or ""
+        raw = str(self.content or "")
+        content_parsed = Markup(raw)
         for text in re.findall(r"\{\{.*?\}\}", raw):
-            reference = text.replace("{{", "").replace("}}", "")
+            reference = re.sub(r"<[^>]*>", "", text).replace("{{", "").replace("}}", "")
             content_parsed = content_parsed.replace(
                 text, self._resolve_reference(reference)
             )
+        link_regex = (
+            r"<a[^>]*class=['\"][^'\"]*oe_direct_line[^'\"]*['\"]"
+            r"[^>]*name=['\"]([^'\"]*)['\"][^>]*>.*?</a>"
+        )
+        for match in re.finditer(link_regex, raw):
+            full_link = match.group(0)
+            reference = match.group(1)
+            content_parsed = content_parsed.replace(
+                Markup(full_link), self._resolve_reference(reference)
+            )
         return content_parsed
+
+    def _inverse_content(self):
+        for rec in self:
+            if rec.type == "content":
+                rec.content = rec.get_content()
+        return super()._inverse_content()
 
     def _resolve_reference(self, code):
         doc = self._get_document(code)
@@ -66,14 +83,15 @@ class DocumentPage(models.Model):
         oe_model = doc._name if doc else self._name
         oe_id = doc.id if doc else ""
         name = html_escape(doc.display_name) if doc else sanitized_code
-        return (
-            f"<a href='#' class='oe_direct_line' data-oe-model='{oe_model}' "
+        href = doc.backend_url if doc else "#"
+        return Markup(
+            f"<a href='{href}' class='oe_direct_line' data-oe-model='{oe_model}' "
             f"data-oe-id='{oe_id}' name='{sanitized_code}'>"
             f"{name}</a>"
         )
 
     def get_raw_content(self):
-        return Markup(self.with_context(raw_reference=True).get_content())
+        return str(self.with_context(raw_reference=True).get_content())
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/document_page_reference/tests/test_document_reference.py
+++ b/document_page_reference/tests/test_document_reference.py
@@ -18,7 +18,7 @@ class TestDocumentReference(BaseCommon):
             {"name": "Test Page 1", "content": Markup("{{r2}}"), "reference": "R1"}
         )
         cls.page2 = cls.page_obj.create(
-            {"name": "Test Page 1", "content": Markup("{{r1}}"), "reference": "r2"}
+            {"name": "Test Page 2", "content": Markup("{{r1}}"), "reference": "r2"}
         )
 
     def test_constraints_duplicate_reference(self):
@@ -31,14 +31,16 @@ class TestDocumentReference(BaseCommon):
         with self.assertRaises(ValidationError):
             self.page2.write({"reference": self.page2.reference + "-02"})
 
-    def test_no_contrains(self):
+    def test_no_constrains(self):
         self.page1.write({"reference": False})
         self.assertFalse(self.page1.reference)
         self.page2.write({"reference": False})
         self.assertFalse(self.page2.reference)
 
     def test_check_raw(self):
-        self.assertEqual(self.page2.display_name, self.page1.get_raw_content())
+        self.assertEqual(
+            str(self.page2.display_name), str(self.page1.get_raw_content())
+        )
 
     def test_auto_reference(self):
         """Test if reference is proposed when saving a page without one."""
@@ -71,5 +73,14 @@ class TestDocumentReference(BaseCommon):
             self.assertEqual(res.get(key), expected_value, f"Mismatch in key: {key}")
 
     def test_compute_content_parsed(self):
-        self.page1.content = Markup("<p></p>")
-        self.assertEqual(self.page1.content_parsed, Markup("<p></p>"))
+        self.page1.content = Markup("<p>{{r2}}</p>")
+        self.assertIn("data-oe-model='document.page'", self.page1.content_parsed)
+        self.assertIn(f"data-oe-id='{self.page2.id}'", self.page1.content_parsed)
+        self.assertIn(f"href='{self.page2.backend_url}'", self.page1.content_parsed)
+        self.assertIn("Test Page 2", self.page1.content_parsed)
+
+    def test_inverse_content_replacement(self):
+        self.page1.content = "{{r2}}"
+        self.assertIn(f"data-oe-id='{self.page2.id}'", self.page1.content)
+        self.assertIn(f"href='{self.page2.backend_url}'", self.page1.content_parsed)
+        self.assertNotIn("&lt;a", self.page1.content)


### PR DESCRIPTION
Currently referencing other documents with {{SOME_REF}} won't result in showing this as a link.

This PR addresses with issue and allows showing link after saving the document.