### PR TITLE
[FIX] document_page_reference: fix for knowledge page report printing

### DIFF
--- a/document_page_reference/models/document_page.py
+++ b/document_page_reference/models/document_page.py
@@ -91,7 +91,7 @@ class DocumentPage(models.Model):
         )
 
     def get_raw_content(self):
-        return str(self.with_context(raw_reference=True).get_content())
+        return Markup(self.with_context(raw_reference=True).get_content())
 
     @api.model_create_multi
     def create(self, vals_list):


### PR DESCRIPTION
Currently, the document PDF report outputs raw HTML. This fix returns functionality which was used before merging PR #609 and aims to resolve report generation issues.