### PR TITLE
[FIX] document_page: make content field span full width in form views

### DIFF
--- a/document_page/views/document_page.xml
+++ b/document_page/views/document_page.xml
@@ -50,13 +50,17 @@
                             <field name="name" placeholder="Name" />
                         </h1>
                     </div>
-                    <field
-                        name="content"
-                        widget="html"
-                        placeholder="e.g. Once upon a time..."
-                        required="1"
-                        options="{'safe': True, 'codeview': True, 'collaborative': True}"
-                    />
+                    <group colspan="2" nolabel="1">
+                        <field
+                            name="content"
+                            widget="html"
+                            placeholder="e.g. Once upon a time..."
+                            required="1"
+                            options="{'safe': True, 'codeview': True, 'collaborative': True}"
+                            nolabel="1"
+                            colspan="2"
+                        />
+                    </group>
                     <notebook>
                         <page name="info" string="Information">
                             <group>

--- a/document_page/views/document_page_history.xml
+++ b/document_page/views/document_page_history.xml
@@ -59,12 +59,16 @@
                     </group>
                     <notebook>
                         <page name="content" string="Content">
-                            <field
-                                name="content"
-                                widget="html"
-                                placeholder="e.g. Once upon a time..."
-                                options="{'safe': True, 'codeview': True}"
-                            />
+                            <group colspan="2" nolabel="1">
+                                <field
+                                    name="content"
+                                    widget="html"
+                                    placeholder="e.g. Once upon a time..."
+                                    options="{'safe': True, 'codeview': True}"
+                                    nolabel="1"
+                                    colspan="2"
+                                />
+                            </group>
                         </page>
                         <page name="diff" string="Changes">
                             <field


### PR DESCRIPTION
The content field was placed directly in the sheet without a group wrapper, which caused it to render in a narrow single column. Wrapping it in a <group colspan="2" nolabel="1"> makes it use the full available width in both the main document form and the history form.