### PR TITLE
[19.0][FIX] document_page, document_knowledge: demo res.users group_ids rename

### DIFF
--- a/document_knowledge/__manifest__.py
+++ b/document_knowledge/__manifest__.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     "name": "Documents Knowledge",
-    "version": "19.0.1.0.0",
+    "version": "19.0.1.0.1",
     "author": "OpenERP SA,"
     "MONK Software, "
     "Tecnativa, "

--- a/document_knowledge/demo/document_knowledge.xml
+++ b/document_knowledge/demo/document_knowledge.xml
@@ -2,7 +2,7 @@
 <odoo noupdate="1">
     <record id="base.user_demo" model="res.users">
         <field
-            name="groups_id"
+            name="group_ids"
             eval="[(4,ref('document_knowledge.group_document_user'))]"
         />
     </record>

--- a/document_page/__manifest__.py
+++ b/document_page/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "Document Page",
-    "version": "19.0.1.0.0",
+    "version": "19.0.1.0.1",
     "category": "Knowledge Management",
     "author": "OpenERP SA, Odoo Community Association (OCA)",
     "images": [

--- a/document_page/demo/document_page.xml
+++ b/document_page/demo/document_page.xml
@@ -3,7 +3,7 @@
     <record id="base.user_demo" model="res.users">
         <field
             eval="[(4, ref('document_knowledge.group_document_user'))]"
-            name="groups_id"
+            name="group_ids"
         />
     </record>
 


### PR DESCRIPTION
In 19.0 `res.users.groups_id` was renamed to `group_ids`. The `base.user_demo`
records in two demo files still use the old field name, so loading demo data on
19.0 fails with:

```
ValueError: Invalid field 'groups_id' in 'res.users'
```

This surfaces wherever demo data is loaded with a current 19.0 build (e.g.
runboat, or any downstream module installed with demo) — `document_page` and
every addon that depends on it (e.g. `document_page_procedure` and the
`management-system` chain) cannot install with demo.

`document_knowledge/data/res_users.xml` was already migrated to `group_ids`;
this aligns the two demo files that were missed.

- `document_knowledge/demo/document_knowledge.xml`
- `document_page/demo/document_page.xml`

Verified: `document_page` installs clean with demo enabled on Odoo 19.0 after
the change.
