### PR TITLE
[19.0][FIX] document_knowledge: res.users.groups_id → group_ids in demo

### DIFF
--- a/document_knowledge/demo/document_knowledge.xml
+++ b/document_knowledge/demo/document_knowledge.xml
@@ -2,7 +2,7 @@
 <odoo noupdate="1">
     <record id="base.user_demo" model="res.users">
         <field
-            name="groups_id"
+            name="group_ids"
             eval="[(4,ref('document_knowledge.group_document_user'))]"
         />
     </record>


### PR DESCRIPTION
`res.users.groups_id` was renamed `group_ids` in 19.0; align the `base.user_demo` demo record.