### PR TITLE
[19.0][FIX] document_page: res.users.groups_id → group_ids in demo

### DIFF
--- a/document_page/demo/document_page.xml
+++ b/document_page/demo/document_page.xml
@@ -3,7 +3,7 @@
     <record id="base.user_demo" model="res.users">
         <field
             eval="[(4, ref('document_knowledge.group_document_user'))]"
-            name="groups_id"
+            name="group_ids"
         />
     </record>
 


### PR DESCRIPTION
`res.users.groups_id` was renamed `group_ids` in 19.0; align the `base.user_demo` demo record.