### PR TITLE
[18.0][FIX] document_page_reference: render content_parsed in OWL form

### DIFF
--- a/document_page_reference/views/document_page.xml
+++ b/document_page_reference/views/document_page.xml
@@ -15,15 +15,16 @@
                     />
                 </h2>
             </xpath>
-            <field name="content" position="attributes">
-                <attribute name="class">oe_edit_only</attribute>
-            </field>
             <field name="content" position="before">
                 <field
                     name="content_parsed"
-                    class="oe_read_only"
+                    readonly="1"
                     widget="document_page_reference"
                 />
+            </field>
+            <field name="content" position="attributes">
+                <attribute name="invisible">type == 'category'</attribute>
+                <attribute name="required">type != 'category'</attribute>
             </field>
         </field>
     </record>
@@ -33,15 +34,15 @@
         <field name="model">document.page</field>
         <field name="inherit_id" ref="document_page.view_wiki_menu_form" />
         <field name="arch" type="xml">
-            <field name="content" position="attributes">
-                <attribute name="class">oe_edit_only</attribute>
-            </field>
             <field name="content" position="before">
                 <field
                     name="content_parsed"
-                    class="oe_read_only"
+                    readonly="1"
                     widget="document_page_reference"
                 />
+            </field>
+            <field name="content" position="attributes">
+                <attribute name="invisible">1</attribute>
             </field>
         </field>
     </record>


### PR DESCRIPTION
The `oe_read_only`/`oe_edit_only` CSS toggle is dead in the OWL form (an open record is always `o_form_editable`), so `content_parsed` rendered with `display:none` — users only ever saw the raw `{{reference}}` text, never the resolved links. This shows `content_parsed` as a plain `readonly` field and gates raw `content` with `invisible`/`required`.

The 17/18/19 widgets are already OWL, so only the view needs this (the 16.0 widget migration is #622). Verified on a runboat build: `content_parsed` goes from `display:none` to a visible, clickable resolved link.
