### PR TITLE
[17.0][IMP] document_page: add button box to history form

### DIFF
--- a/document_page/views/document_page_history.xml
+++ b/document_page/views/document_page_history.xml
@@ -44,6 +44,7 @@
         <field name="arch" type="xml">
             <form string="Document Page History">
                 <sheet>
+                    <div name="button_box" class="oe_button_box" />
                     <h1>
                         <field name="page_id" readonly="1" />
                     </h1>


### PR DESCRIPTION
Adds a standard `button_box` to the document page history form so submodules can attach smart buttons without having to recreate the sheet structure.