### PR TITLE
[IMP] document_page: track changes on active field

### DIFF
--- a/document_page/models/document_page.py
+++ b/document_page/models/document_page.py
@@ -21,7 +21,7 @@ class DocumentPage(models.Model):
         help="Page type",
         default="content",
     )
-    active = fields.Boolean(default=True)
+    active = fields.Boolean(default=True, tracking=True)
     parent_id = fields.Many2one(
         "document.page", "Category", domain=[("type", "=", "category")]
     )


### PR DESCRIPTION
Archiving or unarchiving a document page is a relevant event for document control, but it currently leaves no trace in the chatter.

`document.page` already inherits `mail.thread`, so this PR simply enables mail tracking on the `active` field. Every archive/unarchive is now recorded in the page's message history, giving document controllers an audit trail of when a page was taken out of circulation and by whom.