### PR TITLE
[19.0][FIX] document_page: Make page_id wider in page history

### DIFF
--- a/document_page/views/document_page_history.xml
+++ b/document_page/views/document_page_history.xml
@@ -43,9 +43,13 @@
         <field name="arch" type="xml">
             <form string="Document Page History">
                 <sheet>
-                    <h1>
-                        <field name="page_id" readonly="1" />
-                    </h1>
+                    <div class="oe_title">
+                        <h1>
+                            <group colspan="2">
+                                <field name="page_id" readonly="1" />
+                            </group>
+                        </h1>
+                    </div>
                     <group>
                         <group>
                             <field name="create_uid" readonly="1" />


### PR DESCRIPTION
Make page_id wider in history form view. Forward port of #602.